### PR TITLE
Normalize API routes

### DIFF
--- a/api/app.ts
+++ b/api/app.ts
@@ -10,9 +10,9 @@ import config from './config';
 import apiRouter from './router/router';
 import mongooseErrorHandler from './router/middleware/mongoose-error-handler';
 import { ApiResponse } from './router/response';
-import { AppError } from 'router/errors/app-error';
-import { InternalError } from 'router/errors/internal-error';
-import { NotFoundError } from 'router/errors/http-errors';
+import { AppError } from './router/errors/app-error';
+import { InternalError } from './router/errors/internal-error';
+import { NotFoundError } from './router/errors/http-errors';
 
 const isProduction = config.nodeEnv === 'production';
 const isTesting = config.nodeEnv === 'test';

--- a/api/app.ts
+++ b/api/app.ts
@@ -1,4 +1,3 @@
-import createError from 'http-errors';
 import express from 'express';
 import compression from 'compression';
 import cors from 'cors';
@@ -10,8 +9,10 @@ import swaggerSpec from './config/swagger';
 import config from './config';
 import apiRouter from './router/router';
 import mongooseErrorHandler from './router/middleware/mongoose-error-handler';
-import { ApiError, ApiResponse } from './router/helpers/response';
-import { ApiErrorCode, ApiErrorDetailCode } from 'router/helpers/error-codes';
+import { ApiResponse } from './router/response';
+import { AppError } from 'router/errors/app-error';
+import { InternalError } from 'router/errors/internal-error';
+import { NotFoundError } from 'router/errors/http-errors';
 
 const isProduction = config.nodeEnv === 'production';
 const isTesting = config.nodeEnv === 'test';
@@ -108,37 +109,27 @@ const buildApp = (): express.Application => {
 
   // catch 404 and forward to error handler
   app.use((req, res, next) => {
-    next(createError(404));
+    next(new NotFoundError());
   });
 
-  // Handle recognized Mongoose errors
+  // Handle recognized Mongoose validation errors
   app.use(mongooseErrorHandler);
 
-  // apiRouter error handler
-  // will not leak stacktrace to user in production
+  // Handle any other errors
   const apiRouterErrorHandler = (err, req, res, next) => {
-    const error: ApiError = {
-      code: ApiErrorCode.InternalServerError,
-      errors: [],
+    const error =
+      err instanceof AppError
+      ? err
+      : new InternalError();
+
+    const body: ApiResponse = {
+      error: {
+        code: error.code,
+        errors: error.details,
+      },
     };
 
-    if (!isProduction && !isTesting) {
-      console.log(err.stack);
-
-      if (err instanceof Error) {
-        error.errors?.push({
-          field: null,
-          code: ApiErrorDetailCode.DevelopmentError,
-          properties: {
-            message: err.message,
-          },
-        });
-      }
-    }
-
-    res
-      .status(err.status || 500)
-      .json({ error } satisfies ApiResponse);
+    res.status(error.status).json(body satisfies ApiResponse);
   };
 
   app.use(apiRouterErrorHandler);

--- a/api/app.ts
+++ b/api/app.ts
@@ -97,7 +97,7 @@ const buildApp = (): express.Application => {
     // Serve Swagger JSON
     app.get('/api-docs.json', (req, res) => {
       res.setHeader('Content-Type', 'application/json');
-      res.send(swaggerSpec);
+      res.json(swaggerSpec);
     });
   }
 

--- a/api/config/swagger.ts
+++ b/api/config/swagger.ts
@@ -78,12 +78,13 @@ const swaggerDefinition = {
 };
 
 // Options for the swagger docs
+// Paths are relative to the api directory (where the server runs from)
 const options = {
   swaggerDefinition,
   // Paths to files containing OpenAPI definitions
   apis: [
-    './api/router/routes/*.js',
-    './api/mongoose/models/*.js',
+    './router/routes/*.ts',
+    './mongoose/schemas/*.ts',
   ],
 };
 

--- a/api/mongoose/schemas/DailyReminder.ts
+++ b/api/mongoose/schemas/DailyReminder.ts
@@ -1,52 +1,6 @@
 import mongoose from 'mongoose';
 import crypto from 'node:crypto';
 
-/**
- * @swagger
- * components:
- *   schemas:
- *     DailyReminder:
- *       type: object
- *       required:
- *         - owner
- *         - hour
- *         - minute
- *         - timezoneOffset
- *       properties:
- *         _id:
- *           type: string
- *           description: The auto-generated ID of the reminder
- *         owner:
- *           type: string
- *           description: The ID of the user who owns this reminder
- *         hour:
- *           type: number
- *           description: The hour of the day for the reminder (0-23) in UTC
- *         minute:
- *           type: number
- *           description: The minute of the hour for the reminder (0-59) in UTC
- *         timezoneOffset:
- *           type: number
- *           description: The timezone offset in minutes
- *         active:
- *           type: boolean
- *           description: Whether the reminder is active
- *         unsubscribeCode:
- *           type: string
- *           description: A unique code for unsubscribing from the reminder
- *         nextOccurrence:
- *           type: number
- *           description: The timestamp of the next occurrence of the reminder
- *         createdAt:
- *           type: string
- *           format: date-time
- *           description: The date and time when the reminder was created
- *         updatedAt:
- *           type: string
- *           format: date-time
- *           description: The date and time when the reminder was last updated
- */
-
 export const DailyReminderSchema = new mongoose.Schema({
   owner: {
     type: mongoose.Schema.Types.ObjectId,

--- a/api/mongoose/schemas/Email.ts
+++ b/api/mongoose/schemas/Email.ts
@@ -4,7 +4,11 @@ export const EmailSchema = new mongoose.Schema({
   from: { type: String, required: true },
   to: { type: String, required: true },
   replyTo: { type: String },
-  headers: { type: Object },
+  headers: {
+    type: Map,
+    of: String,
+    default: {},
+  },
   subject: { type: String, required: true },
   text: { type: String },
   html: { type: String },

--- a/api/mongoose/schemas/LogEntry.ts
+++ b/api/mongoose/schemas/LogEntry.ts
@@ -2,44 +2,6 @@ import mongoose from 'mongoose';
 
 import { Bible, SimpleDate } from '@mybiblelog/shared';
 
-/**
- * @swagger
- * components:
- *   schemas:
- *     LogEntry:
- *       type: object
- *       required:
- *         - owner
- *         - date
- *         - startVerseId
- *         - endVerseId
- *       properties:
- *         _id:
- *           type: string
- *           description: The auto-generated ID of the log entry
- *         owner:
- *           type: string
- *           description: The ID of the user who owns this log entry
- *         date:
- *           type: string
- *           format: date
- *           description: The date of the log entry
- *         startVerseId:
- *           type: number
- *           description: The ID of the starting verse
- *         endVerseId:
- *           type: number
- *           description: The ID of the ending verse
- *         createdAt:
- *           type: string
- *           format: date-time
- *           description: The date and time when the log entry was created
- *         updatedAt:
- *           type: string
- *           format: date-time
- *           description: The date and time when the log entry was last updated
- */
-
 export const LogEntrySchema = new mongoose.Schema({
   owner: {
     type: mongoose.Schema.Types.ObjectId,

--- a/api/mongoose/schemas/PassageNote.ts
+++ b/api/mongoose/schemas/PassageNote.ts
@@ -1,58 +1,6 @@
 import mongoose, { InferSchemaType } from 'mongoose';
 import { Bible } from '@mybiblelog/shared';
 
-/**
- * @swagger
- * components:
- *   schemas:
- *     Passage:
- *       type: object
- *       required:
- *         - startVerseId
- *         - endVerseId
- *       properties:
- *         startVerseId:
- *           type: number
- *           description: The ID of the starting verse
- *         endVerseId:
- *           type: number
- *           description: The ID of the ending verse
- *     PassageNote:
- *       type: object
- *       required:
- *         - owner
- *         - passages
- *         - content
- *       properties:
- *         _id:
- *           type: string
- *           description: The auto-generated ID of the passage note
- *         owner:
- *           type: string
- *           description: The ID of the user who owns this note
- *         passages:
- *           type: array
- *           items:
- *             $ref: '#/components/schemas/Passage'
- *           description: The Bible passages this note is associated with
- *         content:
- *           type: string
- *           description: The content of the note
- *         tags:
- *           type: array
- *           items:
- *             type: string
- *           description: Array of tag IDs associated with this note
- *         createdAt:
- *           type: string
- *           format: date-time
- *           description: The date and time when the note was created
- *         updatedAt:
- *           type: string
- *           format: date-time
- *           description: The date and time when the note was last updated
- */
-
 const PassageSchema = new mongoose.Schema({
   startVerseId: {
     type: Number,

--- a/api/mongoose/schemas/PassageNoteTag.ts
+++ b/api/mongoose/schemas/PassageNoteTag.ts
@@ -1,44 +1,5 @@
 import mongoose from 'mongoose';
 
-/**
- * @swagger
- * components:
- *   schemas:
- *     PassageNoteTag:
- *       type: object
- *       required:
- *         - owner
- *         - label
- *         - color
- *       properties:
- *         _id:
- *           type: string
- *           description: The auto-generated ID of the tag
- *         owner:
- *           type: string
- *           description: The ID of the user who owns this tag
- *         label:
- *           type: string
- *           description: The label of the tag
- *         color:
- *           type: string
- *           description: The color of the tag (hex code)
- *         description:
- *           type: string
- *           description: The description of the tag
- *         noteCount:
- *           type: number
- *           description: The number of notes using this tag (computed field)
- *         createdAt:
- *           type: string
- *           format: date-time
- *           description: The date and time when the tag was created
- *         updatedAt:
- *           type: string
- *           format: date-time
- *           description: The date and time when the tag was last updated
- */
-
 export const PassageNoteTagSchema = new mongoose.Schema({
   owner: {
     type: mongoose.Schema.Types.ObjectId,

--- a/api/mongoose/schemas/User.ts
+++ b/api/mongoose/schemas/User.ts
@@ -6,67 +6,6 @@ import jwt from 'jsonwebtoken';
 import config from '../../config';
 import { UserSettingsSchema } from './UserSettings';
 
-/**
- * @swagger
- * components:
- *   schemas:
- *     User:
- *       type: object
- *       required:
- *         - email
- *       properties:
- *         _id:
- *           type: string
- *           description: The auto-generated ID of the user
- *         email:
- *           type: string
- *           description: The user's email address
- *         isAdmin:
- *           type: boolean
- *           description: Whether the user is an admin
- *         password:
- *           type: string
- *           description: The user's hashed password
- *         googleId:
- *           type: string
- *           description: The user's Google ID (if using Google OAuth)
- *         emailVerificationCode:
- *           type: string
- *           description: Code for verifying the user's email
- *         newEmail:
- *           type: string
- *           description: New email address for email change process
- *         newEmailVerificationCode:
- *           type: string
- *           description: Code for verifying the new email
- *         newEmailVerificationExpires:
- *           type: string
- *           format: date-time
- *           description: Expiration time for the new email verification code
- *         oldEmails:
- *           type: array
- *           items:
- *             type: string
- *           description: List of previous email addresses
- *         passwordResetCode:
- *           type: string
- *           description: Code for resetting the password
- *         passwordResetExpires:
- *           type: string
- *           format: date-time
- *           description: Expiration time for the password reset code
- *         settings:
- *           $ref: '#/components/schemas/UserSettings'
- *         createdAt:
- *           type: string
- *           format: date-time
- *           description: The date and time when the user was created
- *         updatedAt:
- *           type: string
- *           format: date-time
- *           description: The date and time when the user was last updated
- */
-
 const SALT_WORK_FACTOR = 10;
 
 export const UserSchema = new mongoose.Schema({

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
     "dev": "cross-env NODE_ENV=development nodemon --exec ts-node server.ts --watch . --watch ../.env --ext ts,js,json",
     "dev:ts": "cross-env NODE_ENV=development nodemon --exec ts-node --transpile-only server.ts --watch . --watch ../.env --ext ts,js,json",
     "build": "tsc",
-    "postbuild": "cp -r services/email-assets dist/services/email-assets",
+    "postbuild": "cp -r services/email/assets dist/services/email/assets",
     "start": "cross-env NODE_ENV=production node dist/server.js",
     "test": "jest ./test",
     "test:serial": "jest --runInBand ./test",

--- a/api/package.json
+++ b/api/package.json
@@ -34,8 +34,6 @@
     "express": "^5.1.0",
     "form-data": "^4.0.4",
     "helmet": "^8.1.0",
-    "http-errors": "^2.0.0",
-    "http-status": "^2.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^9.0.0",
     "mongoose-unique-validator": "^5.0.1",

--- a/api/router/errors/app-error.ts
+++ b/api/router/errors/app-error.ts
@@ -1,0 +1,16 @@
+import { ApiErrorDetail } from '../response';
+import { type ApiErrorCode } from './error-codes';
+
+/**
+ * Represents a base error class for all application errors.
+ */
+export abstract class AppError extends Error {
+  abstract readonly status: number;
+  abstract readonly code: ApiErrorCode;
+  readonly details?: ApiErrorDetail[];
+
+  constructor(message?: string, details?: ApiErrorDetail[]) {
+    super(message);
+    this.details = details;
+  }
+}

--- a/api/router/errors/error-codes.ts
+++ b/api/router/errors/error-codes.ts
@@ -45,6 +45,7 @@ export const ApiErrorDetailCode = {
   PasswordResetLinkExpired: 'password_reset_link_expired',
   EmailNotVerified: 'email_not_verified',
   VerificationCodeExpired: 'verification_code_expired',
+  AdminCannotDeleteOwnAccount: 'admin_cannot_delete_own_account',
 };
 
 export type ApiErrorDetailCode = typeof ApiErrorDetailCode[keyof typeof ApiErrorDetailCode];

--- a/api/router/errors/error-codes.ts
+++ b/api/router/errors/error-codes.ts
@@ -15,6 +15,8 @@ export const ApiErrorCode = {
   InternalServerError: 'internal_server_error', // 500
 };
 
+export type ApiErrorCode = typeof ApiErrorCode[keyof typeof ApiErrorCode];
+
 /**
  * Represents all possible detail errors that can be thrown by the API.
  * These codes are used to map to i18n keys for translation.
@@ -43,7 +45,6 @@ export const ApiErrorDetailCode = {
   PasswordResetLinkExpired: 'password_reset_link_expired',
   EmailNotVerified: 'email_not_verified',
   VerificationCodeExpired: 'verification_code_expired',
-
-  // Development Errors (only to be send in non-production environments)
-  DevelopmentError: 'development_error',
 };
+
+export type ApiErrorDetailCode = typeof ApiErrorDetailCode[keyof typeof ApiErrorDetailCode];

--- a/api/router/errors/http-errors.ts
+++ b/api/router/errors/http-errors.ts
@@ -1,0 +1,48 @@
+import { AppError } from './app-error';
+import { ApiErrorCode } from './error-codes';
+import { ApiErrorDetail } from '../response';
+
+export class UnauthenticatedError extends AppError {
+  status = 401;
+  code = ApiErrorCode.Unauthenticated;
+
+  constructor(details?: ApiErrorDetail[]) {
+    super('Authentication required', details);
+  }
+}
+
+export class UnauthorizedError extends AppError {
+  status = 403;
+  code = ApiErrorCode.Unauthorized;
+
+  constructor(details?: ApiErrorDetail[]) {
+    super('Forbidden', details);
+  }
+}
+
+export class InvalidRequestError extends AppError {
+  status = 400;
+  code = ApiErrorCode.InvalidRequest;
+
+  constructor(details?: ApiErrorDetail[]) {
+    super('Invalid request', details);
+  }
+}
+
+export class NotFoundError extends AppError {
+  status = 404;
+  code = ApiErrorCode.NotFound;
+
+  constructor(details?: ApiErrorDetail[]) {
+    super('Not found', details);
+  }
+}
+
+export class TooManyRequestsError extends AppError {
+  status = 429;
+  code = ApiErrorCode.TooManyRequests;
+
+  constructor(details?: ApiErrorDetail[]) {
+    super('Too many requests', details);
+  }
+}

--- a/api/router/errors/internal-error.ts
+++ b/api/router/errors/internal-error.ts
@@ -1,0 +1,11 @@
+import { AppError } from './app-error';
+import { ApiErrorCode } from './error-codes';
+
+export class InternalError extends AppError {
+  status = 500;
+  code = ApiErrorCode.InternalServerError;
+
+  constructor() {
+    super('Internal server error');
+  }
+}

--- a/api/router/errors/validation-errors.ts
+++ b/api/router/errors/validation-errors.ts
@@ -1,0 +1,12 @@
+import { AppError } from './app-error';
+import { ApiErrorCode } from './error-codes';
+import { ApiErrorDetail } from '../response';
+
+export class ValidationError extends AppError {
+  status = 400;
+  code = ApiErrorCode.ValidationError;
+
+  constructor(details?: ApiErrorDetail[]) {
+    super('Validation failed', details);
+  }
+}

--- a/api/router/helpers/error-codes.ts
+++ b/api/router/helpers/error-codes.ts
@@ -43,4 +43,7 @@ export const ApiErrorDetailCode = {
   PasswordResetLinkExpired: 'password_reset_link_expired',
   EmailNotVerified: 'email_not_verified',
   VerificationCodeExpired: 'verification_code_expired',
+
+  // Development Errors (only to be send in non-production environments)
+  DevelopmentError: 'development_error',
 };

--- a/api/router/helpers/error-codes.ts
+++ b/api/router/helpers/error-codes.ts
@@ -1,11 +1,28 @@
 /**
- * Represents all possible errors that can be thrown by the API.
+ * Represents all possible top-level errors that can be thrown by the API.
  * These codes are used to map to i18n keys for translation.
  *
  * Keep in sync with locales/locale.d.ts
  * @enum {string}
  */
-export const I18nError = {
+export const ApiErrorCode = {
+  ValidationError: 'validation_error', // 400
+  InvalidRequest: 'invalid_request', // 400
+  Unauthenticated: 'unauthenticated', // 401
+  Unauthorized: 'unauthorized', // 403
+  NotFound: 'not_found', // 404
+  TooManyRequests: 'too_many_requests', // 429
+  InternalServerError: 'internal_server_error', // 500
+};
+
+/**
+ * Represents all possible detail errors that can be thrown by the API.
+ * These codes are used to map to i18n keys for translation.
+ *
+ * Keep in sync with locales/locale.d.ts
+ * @enum {string}
+ */
+export const ApiErrorDetailCode = {
   // Request Input Validation Errors
   // (these come from mongoose validation errors)
   Required: 'required',
@@ -24,20 +41,6 @@ export const I18nError = {
   PasswordIncorrect: 'password_incorrect',
   AccountNotFound: 'account_not_found',
   PasswordResetLinkExpired: 'password_reset_link_expired',
-  TooManyRequests: 'too_many_requests', // 429
-  InvalidRequest: 'invalid_request',
   EmailNotVerified: 'email_not_verified',
   VerificationCodeExpired: 'verification_code_expired',
 };
-
-/**
- * Creates an error that can be thrown by the API and translated on the frontend.
- * @param {I18nError} code
- * @param {string} field
- * @param {object} properties
- */
-export const makeI18nError = (code: string, field?: string, properties: Record<string, unknown> = {}) => ({
-  code: `api_error.${code}`, // prefix for i18n key
-  field,
-  properties,
-});

--- a/api/router/helpers/i18n-error.ts
+++ b/api/router/helpers/i18n-error.ts
@@ -7,6 +7,7 @@
  */
 export const I18nError = {
   // Request Input Validation Errors
+  // (these come from mongoose validation errors)
   Required: 'required',
   NotValid: 'not_valid',
   Unique: 'unique',
@@ -31,12 +32,12 @@ export const I18nError = {
 
 /**
  * Creates an error that can be thrown by the API and translated on the frontend.
- * @param {I18nError} kind
+ * @param {I18nError} code
  * @param {string} field
  * @param {object} properties
  */
-export const makeI18nError = (kind: string, field?: string, properties: Record<string, unknown> = {}) => ({
-  kind: `api_error.${kind}`, // prefix for i18n key
+export const makeI18nError = (code: string, field?: string, properties: Record<string, unknown> = {}) => ({
+  code: `api_error.${code}`, // prefix for i18n key
   field,
   properties,
 });

--- a/api/router/helpers/rateLimit.ts
+++ b/api/router/helpers/rateLimit.ts
@@ -1,6 +1,5 @@
-import createError from 'http-errors';
-import status from 'http-status';
 import { type Request } from 'express';
+import { TooManyRequestsError } from 'router/errors/http-errors';
 
 const defaultReqIdentifierFn = (req: Request): string => {
   return req.ip || 'unknown';
@@ -64,7 +63,7 @@ const rateLimit = (
 
   // check if the limit is exceeded before adding the current request
   if (rateLimitStore[key].length >= maxRequests) {
-    throw createError(status.TOO_MANY_REQUESTS, 'Rate limit exceeded');
+    throw new TooManyRequestsError();
   }
 
   // add the current time to the rate limit store for this key

--- a/api/router/helpers/rateLimit.ts
+++ b/api/router/helpers/rateLimit.ts
@@ -1,5 +1,5 @@
 import { type Request } from 'express';
-import { TooManyRequestsError } from 'router/errors/http-errors';
+import { TooManyRequestsError } from '../errors/http-errors';
 
 const defaultReqIdentifierFn = (req: Request): string => {
   return req.ip || 'unknown';

--- a/api/router/helpers/response.ts
+++ b/api/router/helpers/response.ts
@@ -1,15 +1,18 @@
+import { ApiErrorCode, ApiErrorDetailCode } from './error-codes';
+
 /**
  * Represents a field-level error.
  */
 export type ApiErrorDetail = {
   /**
-   * Optional field name for field-level errors.
+   * Field name for field-level errors.
+   * Set to `null` for top-level errors.
    */
-  field?: string;
+  field: string | null;
   /**
    * Machine-readable i18n-friendly code.
    */
-  code: string;
+  code: typeof ApiErrorDetailCode[keyof typeof ApiErrorDetailCode];
   /**
    * Optional metadata for the error. This can be used to pass additional information to the error.
    */
@@ -23,7 +26,7 @@ export type ApiError = {
   /**
    * Top-level error code.
    */
-  code: string;
+  code: typeof ApiErrorCode[keyof typeof ApiErrorCode];
   /**
    * Optional array of field errors.
    */

--- a/api/router/helpers/response.ts
+++ b/api/router/helpers/response.ts
@@ -1,0 +1,38 @@
+/**
+ * Represents a field-level error.
+ */
+export type ApiErrorDetail = {
+  /**
+   * Optional field name for field-level errors.
+   */
+  field?: string;
+  /**
+   * Machine-readable i18n-friendly code.
+   */
+  code: string;
+  /**
+   * Optional metadata for the error. This can be used to pass additional information to the error.
+   */
+  properties?: Record<string, any>;
+};
+
+/**
+ * Represents a top-level error.
+ */
+export type ApiError = {
+  /**
+   * Top-level error code.
+   */
+  code: string;
+  /**
+   * Optional array of field errors.
+   */
+  errors?: ApiErrorDetail[];
+};
+
+/**
+ * Represents a response from the API.
+ */
+export type ApiResponse<T = any> =
+  | { data: T; meta?: Record<string, any>; error?: never }
+  | { data?: never; meta?: never; error: ApiError };

--- a/api/router/middleware/mongoose-error-handler.ts
+++ b/api/router/middleware/mongoose-error-handler.ts
@@ -1,7 +1,8 @@
 import { type Request, type Response, type NextFunction } from 'express';
-import { ApiErrorCode, ApiErrorDetailCode } from '../helpers/error-codes';
+import { ApiErrorCode, ApiErrorDetailCode } from '../errors/error-codes';
 import { Error } from 'mongoose';
-import { ApiErrorDetail, ApiError, ApiResponse } from '../helpers/response';
+import { ApiErrorDetail, ApiError, ApiResponse } from '../response';
+import { ValidationError } from 'router/errors/validation-errors';
 
 // Maps mongoose validation errors to i18n keys
 const MongooseErrorKinds = {
@@ -60,12 +61,7 @@ const mongooseErrorHandler = (err: any, req: Request, res: Response, next: NextF
     errors.push({ code: errorCode, field, properties });
   }
 
-  const error: ApiError = {
-    code: ApiErrorCode.ValidationError,
-    errors,
-  };
-
-  return res.status(422).json({ error } satisfies ApiResponse);
+  throw new ValidationError(errors);
 };
 
 export default mongooseErrorHandler;

--- a/api/router/middleware/mongoose-error-handler.ts
+++ b/api/router/middleware/mongoose-error-handler.ts
@@ -1,8 +1,8 @@
 import { type Request, type Response, type NextFunction } from 'express';
-import { ApiErrorCode, ApiErrorDetailCode } from '../errors/error-codes';
+import { ApiErrorDetailCode } from '../errors/error-codes';
 import { Error } from 'mongoose';
-import { ApiErrorDetail, ApiError, ApiResponse } from '../response';
-import { ValidationError } from 'router/errors/validation-errors';
+import { ApiErrorDetail } from '../response';
+import { ValidationError } from '../errors/validation-errors';
 
 // Maps mongoose validation errors to i18n keys
 const MongooseErrorKinds = {

--- a/api/router/response.ts
+++ b/api/router/response.ts
@@ -1,4 +1,4 @@
-import { ApiErrorCode, ApiErrorDetailCode } from './error-codes';
+import { type ApiErrorCode, type ApiErrorDetailCode } from './errors/error-codes';
 
 /**
  * Represents a field-level error.
@@ -12,7 +12,7 @@ export type ApiErrorDetail = {
   /**
    * Machine-readable i18n-friendly code.
    */
-  code: typeof ApiErrorDetailCode[keyof typeof ApiErrorDetailCode];
+  code: ApiErrorDetailCode;
   /**
    * Optional metadata for the error. This can be used to pass additional information to the error.
    */
@@ -26,7 +26,7 @@ export type ApiError = {
   /**
    * Top-level error code.
    */
-  code: typeof ApiErrorCode[keyof typeof ApiErrorCode];
+  code: ApiErrorCode;
   /**
    * Optional array of field errors.
    */

--- a/api/router/routes/admin.ts
+++ b/api/router/routes/admin.ts
@@ -6,6 +6,7 @@ import authCurrentUser, { setAuthTokenCookie } from '../helpers/authCurrentUser'
 import useMongooseModels from '../../mongoose/useMongooseModels';
 import deleteAccount from '../helpers/deleteAccount';
 import { IUser } from '../../mongoose/schemas/User';
+import { type ApiResponse } from '../helpers/response';
 
 dayjs.extend(utc);
 
@@ -161,7 +162,7 @@ router.get('/admin/feedback', async (req, res, next) => {
       .find()
       .sort({ createdAt: -1 })
       .exec();
-    res.send({ data: feedback });
+    res.send({ data: feedback } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -209,7 +210,7 @@ router.get('/admin/reports/user-engagement/past-week', async (req, res, next) =>
   try {
     await authCurrentUser(req, { adminOnly: true });
     const engagementData = await getPastWeekEngagement();
-    res.send({ data: engagementData });
+    res.send({ data: engagementData } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -417,7 +418,7 @@ router.get('/admin/users', async (req, res, next) => {
       },
     };
 
-    return res.send({ data: users, meta });
+    return res.send({ data: users, meta } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -466,7 +467,7 @@ router.get('/admin/users/:email', async (req, res, next) => {
     if (!user) {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
-    res.send({ data: user });
+    res.send({ data: user } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -531,7 +532,7 @@ router.get('/admin/users/:email/login', async (req, res, next) => {
 
     const token = user.generateJWT();
     setAuthTokenCookie(res, token);
-    res.json({ data: { token } });
+    res.json({ data: { token } } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -580,7 +581,7 @@ router.delete('/admin/users/:email', async (req, res, next) => {
     if (!success) {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
-    res.send({ data: 1 });
+    res.send({ data: 1 } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/admin.ts
+++ b/api/router/routes/admin.ts
@@ -162,7 +162,7 @@ router.get('/admin/feedback', async (req, res, next) => {
       .find()
       .sort({ createdAt: -1 })
       .exec();
-    res.send({ data: feedback } as ApiResponse);
+    res.json({ data: feedback } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -210,7 +210,7 @@ router.get('/admin/reports/user-engagement/past-week', async (req, res, next) =>
   try {
     await authCurrentUser(req, { adminOnly: true });
     const engagementData = await getPastWeekEngagement();
-    res.send({ data: engagementData } as ApiResponse);
+    res.json({ data: engagementData } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -418,7 +418,7 @@ router.get('/admin/users', async (req, res, next) => {
       },
     };
 
-    return res.send({ data: users, meta } as ApiResponse);
+    return res.json({ data: users, meta } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -467,7 +467,7 @@ router.get('/admin/users/:email', async (req, res, next) => {
     if (!user) {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
-    res.send({ data: user } as ApiResponse);
+    res.json({ data: user } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -581,7 +581,7 @@ router.delete('/admin/users/:email', async (req, res, next) => {
     if (!success) {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
-    res.send({ data: 1 } as ApiResponse);
+    res.json({ data: 1 } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/admin.ts
+++ b/api/router/routes/admin.ts
@@ -8,6 +8,7 @@ import deleteAccount from '../helpers/deleteAccount';
 import { IUser } from '../../mongoose/schemas/User';
 import { type ApiResponse } from '../response';
 import { InvalidRequestError, NotFoundError } from '../errors/http-errors';
+import { ApiErrorDetailCode } from 'router/errors/error-codes';
 
 dayjs.extend(utc);
 
@@ -736,9 +737,7 @@ router.delete('/admin/users/:email', async (req, res, next) => {
 
     // Prevent admin from deleting their own account
     if (currentUser.email === email) {
-      // FIXME: see if we use this error on the frontend, and if so, add detail:
-      // FIXME: admin_cannot_delete_own_account "You cannot delete your own admin account"
-      throw new InvalidRequestError();
+      throw new InvalidRequestError([{ code: ApiErrorDetailCode.AdminCannotDeleteOwnAccount, field: null }]);
     }
 
     const success = await deleteAccount(email);

--- a/api/router/routes/admin.ts
+++ b/api/router/routes/admin.ts
@@ -8,7 +8,7 @@ import deleteAccount from '../helpers/deleteAccount';
 import { IUser } from '../../mongoose/schemas/User';
 import { type ApiResponse } from '../response';
 import { InvalidRequestError, NotFoundError } from '../errors/http-errors';
-import { ApiErrorDetailCode } from 'router/errors/error-codes';
+import { ApiErrorDetailCode } from '../errors/error-codes';
 
 dayjs.extend(utc);
 

--- a/api/router/routes/admin.ts
+++ b/api/router/routes/admin.ts
@@ -6,8 +6,8 @@ import authCurrentUser, { setAuthTokenCookie } from '../helpers/authCurrentUser'
 import useMongooseModels from '../../mongoose/useMongooseModels';
 import deleteAccount from '../helpers/deleteAccount';
 import { IUser } from '../../mongoose/schemas/User';
-import { ApiErrorCode } from '../helpers/error-codes';
-import { type ApiResponse } from '../helpers/response';
+import { ApiErrorCode } from '../errors/error-codes';
+import { type ApiResponse } from '../response';
 
 dayjs.extend(utc);
 

--- a/api/router/routes/admin.ts
+++ b/api/router/routes/admin.ts
@@ -130,6 +130,52 @@ const getPastWeekEngagement = async () => {
   return engagementData;
 };
 
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     AdminUser:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *           description: The auto-generated ID of the user
+ *         email:
+ *           type: string
+ *           description: The user's email address
+ *         isAdmin:
+ *           type: boolean
+ *           description: Whether the user has admin privileges
+ *         settings:
+ *           $ref: '#/components/schemas/UserSettings'
+ *         googleId:
+ *           type: string
+ *           nullable: true
+ *           description: The user's Google ID (if using Google OAuth)
+ *         newEmail:
+ *           type: string
+ *           nullable: true
+ *           description: New email address for email change process
+ *         oldEmails:
+ *           type: array
+ *           items:
+ *             type: string
+ *           description: List of previous email addresses
+ *         emailVerificationExpires:
+ *           type: string
+ *           format: date-time
+ *           nullable: true
+ *           description: Expiration time for email verification
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *           description: The date and time when the user was created
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *           description: The date and time when the user was last updated
+ */
+
 const router = express.Router();
 
 /**
@@ -146,13 +192,26 @@ const router = express.Router();
  *         content:
  *           application/json:
  *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Feedback'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Feedback'
  *       401:
  *         description: Unauthorized - User is not authenticated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       403:
  *         description: Forbidden - User is not an admin
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 // GET all feedback
 router.get('/admin/feedback', async (req, res, next) => {
@@ -184,27 +243,40 @@ router.get('/admin/feedback', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               type: array
- *               items:
- *                 type: object
- *                 properties:
- *                   date:
- *                     type: string
- *                     format: date
- *                     description: Date of the engagement data
- *                   newUserAccounts:
- *                     type: number
- *                     description: Number of new user accounts created on this date
- *                   usersWithLogEntry:
- *                     type: number
- *                     description: Number of users who created log entries on this date
- *                   usersWithNote:
- *                     type: number
- *                     description: Number of users who created notes on this date
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       date:
+ *                         type: string
+ *                         format: date
+ *                         description: Date of the engagement data
+ *                       newUserAccounts:
+ *                         type: number
+ *                         description: Number of new user accounts created on this date
+ *                       usersWithLogEntry:
+ *                         type: number
+ *                         description: Number of users who created log entries on this date
+ *                       usersWithNote:
+ *                         type: number
+ *                         description: Number of users who created notes on this date
  *       401:
  *         description: Unauthorized - User is not authenticated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       403:
  *         description: Forbidden - User is not an admin
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 // GET past week user engagement report
 router.get('/admin/reports/user-engagement/past-week', async (req, res, next) => {
@@ -341,24 +413,46 @@ const validateQuery = (query: {
  *           application/json:
  *             schema:
  *               type: object
+ *               required:
+ *                 - data
  *               properties:
- *                 offset:
- *                   type: number
- *                   description: The offset of the results
- *                 limit:
- *                   type: number
- *                   description: The maximum number of results returned
- *                 size:
- *                   type: number
- *                   description: The total number of results available
- *                 results:
+ *                 data:
  *                   type: array
  *                   items:
- *                     $ref: '#/components/schemas/User'
+ *                     $ref: '#/components/schemas/AdminUser'
+ *                 meta:
+ *                   type: object
+ *                   properties:
+ *                     pagination:
+ *                       type: object
+ *                       properties:
+ *                         offset:
+ *                           type: number
+ *                           description: The offset of the results
+ *                         limit:
+ *                           type: number
+ *                           description: The maximum number of results returned
+ *                         size:
+ *                           type: number
+ *                           description: The total number of results available
+ *       400:
+ *         description: Invalid request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       401:
  *         description: Unauthorized - User is not authenticated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       403:
  *         description: Forbidden - User is not an admin
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 // GET list users
 router.get('/admin/users', async (req, res, next) => {
@@ -447,13 +541,37 @@ router.get('/admin/users', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/User'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     _id:
+ *                       type: string
+ *                       description: The auto-generated ID of the user
+ *                     email:
+ *                       type: string
+ *                       description: The user's email address
  *       401:
  *         description: Unauthorized - User is not authenticated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       403:
  *         description: Forbidden - User is not an admin
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: User not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 // GET a user
 router.get('/admin/users/:email', async (req, res, next) => {
@@ -508,16 +626,33 @@ router.get('/admin/users/:email', async (req, res, next) => {
  *           application/json:
  *             schema:
  *               type: object
+ *               required:
+ *                 - data
  *               properties:
- *                 token:
- *                   type: string
- *                   description: Token for authentication
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     token:
+ *                       type: string
+ *                       description: Token for authentication
  *       401:
  *         description: Unauthorized - User is not authenticated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       403:
  *         description: Forbidden - User is not an admin
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: User not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 // GET a JWT to login as a user
 router.get('/admin/users/:email/login', async (req, res, next) => {
@@ -558,14 +693,40 @@ router.get('/admin/users/:email/login', async (req, res, next) => {
  *     responses:
  *       200:
  *         description: User deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: number
+ *                   description: Number of deleted users (1)
  *       400:
  *         description: Bad Request - Cannot delete your own admin account
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       401:
  *         description: Unauthorized - User is not authenticated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       403:
  *         description: Forbidden - User is not an admin
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: User not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 // DELETE a user
 router.delete('/admin/users/:email', async (req, res, next) => {

--- a/api/router/routes/auth.ts
+++ b/api/router/routes/auth.ts
@@ -481,13 +481,7 @@ router.get('/auth/oauth2/google/url', (req, res, next) => {
  *                       type: string
  *                       description: Token for authentication
  *       400:
- *         description: Invalid code or OAuth2 error
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
- *       400:
- *         description: Validation error (e.g., email not verified)
+ *         description: Invalid code, OAuth2 error, or validation error (e.g., email not verified)
  *         content:
  *           application/json:
  *             schema:
@@ -1006,19 +1000,13 @@ router.delete('/auth/change-email', async (req, res, next) => {
  *                       type: string
  *                       description: Token for authentication
  *       400:
- *         description: Verification code expired
+ *         description: Verification code expired or email already in use
  *         content:
  *           application/json:
  *             schema:
  *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: Email verification code not found
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/ApiErrorResponse'
- *       400:
- *         description: Email already in use
  *         content:
  *           application/json:
  *             schema:

--- a/api/router/routes/auth.ts
+++ b/api/router/routes/auth.ts
@@ -11,9 +11,8 @@ import UserSettings from '../../mongoose/schemas/UserSettings';
 import { isEmailVerified } from '../../mongoose/schemas/User';
 import { LocaleCode } from '@mybiblelog/shared';
 import { type ApiResponse } from '../response';
-import { ValidationError } from 'router/errors/validation-errors';
-import { InvalidRequestError, NotFoundError } from 'router/errors/http-errors';
-import { UnauthorizedError } from 'router/errors/http-errors';
+import { ValidationError } from '../errors/validation-errors';
+import { InvalidRequestError, UnauthorizedError, NotFoundError } from '../errors/http-errors';
 
 const { requireEmailVerification } = config;
 

--- a/api/router/routes/auth.ts
+++ b/api/router/routes/auth.ts
@@ -368,7 +368,7 @@ router.post('/auth/register', async (req, res, next) => {
  */
 router.get('/auth/oauth2/google/url', (req, res, next) => {
   const { url, state } = googleOauth2.getGoogleLoginUrl();
-  res.send({ data: { url, state } } as ApiResponse);
+  res.json({ data: { url, state } } as ApiResponse);
 });
 
 /**
@@ -458,7 +458,7 @@ router.get('/auth/oauth2/google/verify', async (req, res, next) => {
 
       const token = existingUser.generateJWT();
       setAuthTokenCookie(res, token);
-      return res.send({ data: { token } } as ApiResponse);
+      return res.json({ data: { token } } as ApiResponse);
     }
 
     // Create new user account
@@ -474,7 +474,7 @@ router.get('/auth/oauth2/google/verify', async (req, res, next) => {
     await user.save();
     const token = user.generateJWT();
     setAuthTokenCookie(res, token);
-    res.send({ data: { token } } as ApiResponse);
+    res.json({ data: { token } } as ApiResponse);
   }
   catch (err) {
     next(err);
@@ -526,7 +526,7 @@ router.get('/auth/verify-email/:emailVerificationCode', async (req, res) => {
   const { User } = await useMongooseModels();
   const user = await User.findOne({ emailVerificationCode });
   if (!user) {
-    return res.sendStatus(404);
+    return res.status(404).json({ error: {} });
   }
 
   // Verify the code and check expiration
@@ -594,7 +594,7 @@ router.put('/auth/change-password', async (req, res, next) => {
     currentUser.password = newPassword;
     try {
       await currentUser.save();
-      res.send({ data: status.OK } as ApiResponse);
+      res.json({ data: status.OK } as ApiResponse);
     }
     catch (err) {
       // Any 'password' validation errors should be seen on the 'newPassword' field
@@ -672,7 +672,7 @@ router.post('/auth/change-email', async (req, res, next) => {
     if (authBypass && currentUser.newEmailVerificationCode) {
       responseData.newEmailVerificationCode = currentUser.newEmailVerificationCode;
     }
-    res.send({ data: responseData } as ApiResponse);
+    res.json({ data: responseData } as ApiResponse);
 
     // send an email update confirmation code
     const emailService = await useEmailService();
@@ -710,7 +710,7 @@ router.get('/auth/change-email', async (req, res, next) => {
     const currentUser = await authCurrentUser(req);
 
     if (currentUser.newEmail) {
-      return res.send({
+      return res.json({
         data: {
           newEmail: currentUser.newEmail,
           expires: currentUser.newEmailVerificationExpires,
@@ -718,7 +718,7 @@ router.get('/auth/change-email', async (req, res, next) => {
       } as ApiResponse);
     }
 
-    return res.send({
+    return res.json({
       data: {
         newEmail: null,
         expires: null,
@@ -755,7 +755,7 @@ router.get('/auth/change-email/:newEmailVerificationCode', async (req, res, next
   const user = await User.findOne({ newEmailVerificationCode });
 
   if (user) {
-    return res.send({
+    return res.json({
       data: {
         newEmail: user.newEmail,
         expires: user.newEmailVerificationExpires,
@@ -763,7 +763,7 @@ router.get('/auth/change-email/:newEmailVerificationCode', async (req, res, next
     } as ApiResponse);
   }
 
-  return res.send({ data: null } as ApiResponse);
+  return res.json({ data: null } as ApiResponse);
 });
 
 /**
@@ -789,14 +789,14 @@ router.delete('/auth/change-email', async (req, res, next) => {
     if (currentUser.newEmail) {
       currentUser.disableEmailUpdate();
       await currentUser.save();
-      return res.send({ data: true } as ApiResponse);
+      return res.json({ data: true } as ApiResponse);
     }
 
-    return res.send({ data: false } as ApiResponse);
+    return res.json({ data: false } as ApiResponse);
   }
   catch (err) {
     console.log(err);
-    return res.send({ data: false } as ApiResponse);
+    return res.json({ data: false } as ApiResponse);
   }
 });
 
@@ -846,7 +846,7 @@ router.post('/auth/change-email/:newEmailVerificationCode', async (req, res, nex
   const { User } = await useMongooseModels();
   const user = await User.findOne({ newEmailVerificationCode });
   if (!user) {
-    return res.sendStatus(404);
+    return res.status(404).json({ error: {} });
   }
 
   // Verify the code and check expiration
@@ -928,7 +928,7 @@ router.post('/auth/reset-password', async (req, res) => {
   if (authBypass && user.passwordResetCode) {
     responseData.passwordResetCode = user.passwordResetCode;
   }
-  res.send({ data: responseData } as ApiResponse);
+  res.json({ data: responseData } as ApiResponse);
 
   // send password reset code via email
   const emailService = await useEmailService();

--- a/api/router/routes/feedback.ts
+++ b/api/router/routes/feedback.ts
@@ -3,6 +3,7 @@ import status from 'http-status';
 import authCurrentUser from '../helpers/authCurrentUser';
 import { I18nError, makeI18nError } from '../helpers/i18n-error';
 import useMongooseModels from '../../mongoose/useMongooseModels';
+import { type ApiResponse } from '../helpers/response';
 
 const router = express.Router();
 
@@ -119,7 +120,7 @@ router.post('/feedback', async (req, res, next) => {
     });
 
     await feedback.save();
-    res.status(status.CREATED).send({ data: feedback.toJSON() });
+    res.status(status.CREATED).send({ data: feedback.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/feedback.ts
+++ b/api/router/routes/feedback.ts
@@ -2,8 +2,7 @@ import express from 'express';
 import authCurrentUser from '../helpers/authCurrentUser';
 import useMongooseModels from '../../mongoose/useMongooseModels';
 import { type ApiResponse } from '../response';
-import { TooManyRequestsError } from 'router/errors/http-errors';
-import rateLimit from 'router/helpers/rateLimit';
+import rateLimit from '../helpers/rateLimit';
 
 const router = express.Router();
 

--- a/api/router/routes/feedback.ts
+++ b/api/router/routes/feedback.ts
@@ -68,15 +68,21 @@ const router = express.Router();
  *     responses:
  *       201:
  *         description: Feedback submitted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/Feedback'
  *       429:
  *         description: Too many requests
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 error:
- *                   type: object
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 
 // POST feedback form submission

--- a/api/router/routes/feedback.ts
+++ b/api/router/routes/feedback.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 import status from 'http-status';
 import authCurrentUser from '../helpers/authCurrentUser';
-import { I18nError, makeI18nError } from '../helpers/i18n-error';
+import { ApiErrorCode } from '../helpers/error-codes';
 import useMongooseModels from '../../mongoose/useMongooseModels';
 import { type ApiResponse } from '../helpers/response';
 
@@ -102,7 +102,7 @@ router.post('/feedback', async (req, res, next) => {
       if (recentFeedbackCount >= 5) {
         return res
           .status(status.TOO_MANY_REQUESTS)
-          .json({ error: { _form: makeI18nError(I18nError.TooManyRequests, '_form') } });
+          .json({ error: { code: ApiErrorCode.TooManyRequests } } satisfies ApiResponse);
       }
     }
 
@@ -120,7 +120,7 @@ router.post('/feedback', async (req, res, next) => {
     });
 
     await feedback.save();
-    res.status(status.CREATED).send({ data: feedback.toJSON() } as ApiResponse);
+    res.status(status.CREATED).send({ data: feedback.toJSON() } satisfies ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/feedback.ts
+++ b/api/router/routes/feedback.ts
@@ -74,7 +74,7 @@ const router = express.Router();
  *             schema:
  *               type: object
  *               properties:
- *                 errors:
+ *                 error:
  *                   type: object
  */
 
@@ -101,7 +101,7 @@ router.post('/feedback', async (req, res, next) => {
       if (recentFeedbackCount >= 5) {
         return res
           .status(status.TOO_MANY_REQUESTS)
-          .json({ errors: { _form: makeI18nError(I18nError.TooManyRequests, '_form') } });
+          .json({ error: { _form: makeI18nError(I18nError.TooManyRequests, '_form') } });
       }
     }
 
@@ -119,7 +119,7 @@ router.post('/feedback', async (req, res, next) => {
     });
 
     await feedback.save();
-    res.sendStatus(status.CREATED);
+    res.status(status.CREATED).send({ data: feedback.toJSON() });
   }
   catch (error) {
     next(error);

--- a/api/router/routes/log-entries.ts
+++ b/api/router/routes/log-entries.ts
@@ -66,11 +66,20 @@ const router = express.Router();
  *         content:
  *           application/json:
  *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/LogEntry'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/LogEntry'
  *       400:
  *         description: Invalid date format
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.get('/log-entries', async (req, res, next) => {
   try {
@@ -130,9 +139,24 @@ router.get('/log-entries', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/LogEntry'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/LogEntry'
+ *       400:
+ *         description: Invalid ID format
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: Log entry not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.get('/log-entries/:id', async (req, res, next) => {
   try {
@@ -187,7 +211,18 @@ router.get('/log-entries/:id', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/LogEntry'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/LogEntry'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.post('/log-entries', async (req, res, next) => {
   try {
@@ -246,9 +281,24 @@ router.post('/log-entries', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/LogEntry'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/LogEntry'
+ *       400:
+ *         description: Invalid ID format or validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: Log entry not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.put('/log-entries/:id', async (req, res, next) => {
   try {
@@ -303,8 +353,28 @@ router.put('/log-entries/:id', async (req, res, next) => {
  *     responses:
  *       200:
  *         description: Log entry deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: number
+ *                   description: Number of deleted entries (1)
+ *       400:
+ *         description: Invalid ID format
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: Log entry not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.delete('/log-entries/:id', async (req, res, next) => {
   try {

--- a/api/router/routes/log-entries.ts
+++ b/api/router/routes/log-entries.ts
@@ -4,6 +4,7 @@ import { SimpleDate } from '@mybiblelog/shared';
 import authCurrentUser from '../helpers/authCurrentUser';
 import useMongooseModels from '../../mongoose/useMongooseModels';
 import { Types } from 'mongoose';
+import { type ApiResponse } from '../helpers/response';
 
 const router = express.Router();
 
@@ -86,21 +87,21 @@ router.get('/log-entries', async (req, res, next) => {
 
     if (!startDate && !endDate) {
       const logEntries = await LogEntry.find({ owner: currentUser._id });
-      return res.send({ data: logEntries });
+      return res.send({ data: logEntries } as ApiResponse);
     }
 
     if (startDate && !endDate) {
       const logEntries = await LogEntry.find({ owner: currentUser._id, date: { $gte: startDate } });
-      return res.send({ data: logEntries });
+      return res.send({ data: logEntries } as ApiResponse);
     }
 
     if (!startDate && endDate) {
       const logEntries = await LogEntry.find({ owner: currentUser._id, date: { $lte: endDate } });
-      return res.send({ data: logEntries });
+      return res.send({ data: logEntries } as ApiResponse);
     }
 
     const logEntries = await LogEntry.find({ owner: currentUser._id, date: { $gte: startDate, $lte: endDate } });
-    return res.send({ data: logEntries });
+    return res.send({ data: logEntries } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -146,7 +147,7 @@ router.get('/log-entries/:id', async (req, res, next) => {
     if (!logEntry) {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
-    res.send({ data: logEntry.toJSON() });
+    res.send({ data: logEntry.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -202,7 +203,7 @@ router.post('/log-entries', async (req, res, next) => {
     }
     await logEntry.save();
 
-    res.send({ data: logEntry.toJSON() });
+    res.send({ data: logEntry.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -276,7 +277,7 @@ router.put('/log-entries/:id', async (req, res, next) => {
     }
     await logEntry.save();
 
-    res.send({ data: logEntry.toJSON() });
+    res.send({ data: logEntry.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -319,7 +320,7 @@ router.delete('/log-entries/:id', async (req, res, next) => {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
 
-    res.send({ data: result.deletedCount });
+    res.send({ data: result.deletedCount } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/log-entries.ts
+++ b/api/router/routes/log-entries.ts
@@ -4,8 +4,8 @@ import { SimpleDate } from '@mybiblelog/shared';
 import authCurrentUser from '../helpers/authCurrentUser';
 import useMongooseModels from '../../mongoose/useMongooseModels';
 import { Types } from 'mongoose';
-import { ApiErrorCode, ApiErrorDetailCode } from '../helpers/error-codes';
-import { type ApiResponse } from '../helpers/response';
+import { ApiErrorCode, ApiErrorDetailCode } from '../errors/error-codes';
+import { type ApiResponse } from '../response';
 
 const router = express.Router();
 

--- a/api/router/routes/log-entries.ts
+++ b/api/router/routes/log-entries.ts
@@ -87,21 +87,21 @@ router.get('/log-entries', async (req, res, next) => {
 
     if (!startDate && !endDate) {
       const logEntries = await LogEntry.find({ owner: currentUser._id });
-      return res.send({ data: logEntries } as ApiResponse);
+      return res.json({ data: logEntries } as ApiResponse);
     }
 
     if (startDate && !endDate) {
       const logEntries = await LogEntry.find({ owner: currentUser._id, date: { $gte: startDate } });
-      return res.send({ data: logEntries } as ApiResponse);
+      return res.json({ data: logEntries } as ApiResponse);
     }
 
     if (!startDate && endDate) {
       const logEntries = await LogEntry.find({ owner: currentUser._id, date: { $lte: endDate } });
-      return res.send({ data: logEntries } as ApiResponse);
+      return res.json({ data: logEntries } as ApiResponse);
     }
 
     const logEntries = await LogEntry.find({ owner: currentUser._id, date: { $gte: startDate, $lte: endDate } });
-    return res.send({ data: logEntries } as ApiResponse);
+    return res.json({ data: logEntries } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -147,7 +147,7 @@ router.get('/log-entries/:id', async (req, res, next) => {
     if (!logEntry) {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
-    res.send({ data: logEntry.toJSON() } as ApiResponse);
+    res.json({ data: logEntry.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -203,7 +203,7 @@ router.post('/log-entries', async (req, res, next) => {
     }
     await logEntry.save();
 
-    res.send({ data: logEntry.toJSON() } as ApiResponse);
+    res.json({ data: logEntry.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -277,7 +277,7 @@ router.put('/log-entries/:id', async (req, res, next) => {
     }
     await logEntry.save();
 
-    res.send({ data: logEntry.toJSON() } as ApiResponse);
+    res.json({ data: logEntry.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -320,7 +320,7 @@ router.delete('/log-entries/:id', async (req, res, next) => {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
 
-    res.send({ data: result.deletedCount } as ApiResponse);
+    res.json({ data: result.deletedCount } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/log-entries.ts
+++ b/api/router/routes/log-entries.ts
@@ -7,7 +7,7 @@ import { Types } from 'mongoose';
 import { ApiErrorDetailCode } from '../errors/error-codes';
 import { type ApiResponse } from '../response';
 import { ValidationError } from '../errors/validation-errors';
-import { InvalidRequestError, NotFoundError } from '../errors/http-errors';
+import { NotFoundError } from '../errors/http-errors';
 
 const router = express.Router();
 

--- a/api/router/routes/log-entries.ts
+++ b/api/router/routes/log-entries.ts
@@ -1,5 +1,4 @@
 import express from 'express';
-import createError from 'http-errors';
 import { ObjectId } from 'mongodb';
 import { SimpleDate } from '@mybiblelog/shared';
 import authCurrentUser from '../helpers/authCurrentUser';
@@ -78,30 +77,30 @@ router.get('/log-entries', async (req, res, next) => {
     const { startDate, endDate } = req.query as { startDate: string; endDate: string };
 
     if (startDate && !SimpleDate.validateString(startDate)) {
-      return next(createError(400, 'Invalid startDate'));
+      return res.status(400).send({ error: { error: { message: 'Invalid startDate' } } });
     }
 
     if (endDate && !SimpleDate.validateString(endDate)) {
-      return next(createError(400, 'Invalid endDate'));
+      return res.status(400).send({ error: { error: { message: 'Invalid endDate' } } });
     }
 
     if (!startDate && !endDate) {
       const logEntries = await LogEntry.find({ owner: currentUser._id });
-      return res.send(logEntries);
+      return res.send({ data: logEntries });
     }
 
     if (startDate && !endDate) {
       const logEntries = await LogEntry.find({ owner: currentUser._id, date: { $gte: startDate } });
-      return res.send(logEntries);
+      return res.send({ data: logEntries });
     }
 
     if (!startDate && endDate) {
       const logEntries = await LogEntry.find({ owner: currentUser._id, date: { $lte: endDate } });
-      return res.send(logEntries);
+      return res.send({ data: logEntries });
     }
 
     const logEntries = await LogEntry.find({ owner: currentUser._id, date: { $gte: startDate, $lte: endDate } });
-    return res.send(logEntries);
+    return res.send({ data: logEntries });
   }
   catch (error) {
     next(error);
@@ -137,7 +136,7 @@ router.get('/log-entries/:id', async (req, res, next) => {
   try {
     const { id } = req.params;
     if (!ObjectId.isValid(id)) {
-      return next(createError(400, 'Invalid ID format'));
+      return res.status(400).send({ error: { error: { message: 'Invalid ID format' } } });
     }
 
     const { LogEntry } = await useMongooseModels();
@@ -145,9 +144,9 @@ router.get('/log-entries/:id', async (req, res, next) => {
 
     const logEntry = await LogEntry.findOne({ owner: currentUser._id, _id: id });
     if (!logEntry) {
-      return next(createError(404, 'Not Found'));
+      return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
-    res.send(logEntry.toJSON());
+    res.send({ data: logEntry.toJSON() });
   }
   catch (error) {
     next(error);
@@ -199,11 +198,11 @@ router.post('/log-entries', async (req, res, next) => {
       await logEntry.validate();
     }
     catch (error) {
-      return next(createError(400, 'Invalid log entry'));
+      return res.status(400).send({ error: { error: { message: 'Invalid log entry' } } });
     }
     await logEntry.save();
 
-    res.send(logEntry.toJSON());
+    res.send({ data: logEntry.toJSON() });
   }
   catch (error) {
     next(error);
@@ -253,7 +252,7 @@ router.put('/log-entries/:id', async (req, res, next) => {
   try {
     const { id } = req.params;
     if (!ObjectId.isValid(id)) {
-      return next(createError(400, 'Invalid ID format'));
+      return res.status(400).send({ error: { error: { message: 'Invalid ID format' } } });
     }
 
     const { LogEntry } = await useMongooseModels();
@@ -262,7 +261,7 @@ router.put('/log-entries/:id', async (req, res, next) => {
 
     const logEntry = await LogEntry.findOne({ owner: currentUser._id, _id: id });
     if (!logEntry) {
-      return next(createError(404, 'Not Found'));
+      return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
 
     if (date) { logEntry.date = date; }
@@ -273,11 +272,11 @@ router.put('/log-entries/:id', async (req, res, next) => {
       await logEntry.validate();
     }
     catch (error) {
-      return next(createError(400, 'Invalid log entry'));
+      return res.status(400).send({ error: { error: { message: 'Invalid log entry' } } });
     }
     await logEntry.save();
 
-    res.send(logEntry.toJSON());
+    res.send({ data: logEntry.toJSON() });
   }
   catch (error) {
     next(error);
@@ -309,7 +308,7 @@ router.delete('/log-entries/:id', async (req, res, next) => {
   try {
     const { id } = req.params;
     if (!ObjectId.isValid(id)) {
-      return next(createError(400, 'Invalid ID format'));
+      return res.status(400).send({ error: { error: { message: 'Invalid ID format' } } });
     }
 
     const { LogEntry } = await useMongooseModels();
@@ -317,10 +316,10 @@ router.delete('/log-entries/:id', async (req, res, next) => {
 
     const result = await LogEntry.deleteOne({ owner: currentUser._id, _id: id });
     if (result.deletedCount === 0) {
-      return next(createError(404, 'Not Found'));
+      return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
 
-    res.send(result.deletedCount);
+    res.send({ data: result.deletedCount });
   }
   catch (error) {
     next(error);

--- a/api/router/routes/passage-note-tags.ts
+++ b/api/router/routes/passage-note-tags.ts
@@ -3,6 +3,7 @@ import { ObjectId } from 'mongodb';
 import authCurrentUser from '../helpers/authCurrentUser';
 import useMongooseModels from '../../mongoose/useMongooseModels';
 import { Types } from 'mongoose';
+import { type ApiResponse } from '../helpers/response';
 
 const router = express.Router();
 
@@ -75,7 +76,7 @@ router.get('/passage-note-tags', async (req, res, next) => {
       passageNoteTag.noteCount = await countTagNotes(passageNoteTag);
     }
 
-    return res.send({ data: passageNoteTags });
+    return res.send({ data: passageNoteTags } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -122,7 +123,7 @@ router.get('/passage-note-tags/:id', async (req, res, next) => {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
     passageNoteTag.noteCount = await countTagNotes(passageNoteTag);
-    res.send({ data: passageNoteTag.toJSON() });
+    res.send({ data: passageNoteTag.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -188,7 +189,7 @@ router.post('/passage-note-tags', async (req, res, next) => {
     }
 
     passageNoteTag.noteCount = 0;
-    res.send({ data: passageNoteTag.toJSON() });
+    res.send({ data: passageNoteTag.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -264,7 +265,7 @@ router.put('/passage-note-tags/:id', async (req, res, next) => {
 
     await passageNoteTag.save();
 
-    res.send({ data: passageNoteTag.toJSON() });
+    res.send({ data: passageNoteTag.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -309,7 +310,7 @@ router.delete('/passage-note-tags/:id', async (req, res, next) => {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
 
-    res.send({ data: result.deletedCount } );
+    res.send({ data: result.deletedCount } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/passage-note-tags.ts
+++ b/api/router/routes/passage-note-tags.ts
@@ -63,9 +63,14 @@ const countTagNotes = async (tag) => {
  *         content:
  *           application/json:
  *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/PassageNoteTag'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PassageNoteTag'
  */
 router.get('/passage-note-tags', async (req, res, next) => {
   try {
@@ -105,9 +110,24 @@ router.get('/passage-note-tags', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PassageNoteTag'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/PassageNoteTag'
+ *       400:
+ *         description: Invalid ID format
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: Passage note tag not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.get('/passage-note-tags/:id', async (req, res, next) => {
   try {
@@ -164,7 +184,24 @@ router.get('/passage-note-tags/:id', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PassageNoteTag'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/PassageNoteTag'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       422:
+ *         description: Validation error (e.g., duplicate label)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.post('/passage-note-tags', async (req, res, next) => {
   try {
@@ -234,9 +271,24 @@ router.post('/passage-note-tags', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PassageNoteTag'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/PassageNoteTag'
+ *       400:
+ *         description: Invalid ID format or validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: Passage note tag not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.put('/passage-note-tags/:id', async (req, res, next) => {
   try {
@@ -291,10 +343,28 @@ router.put('/passage-note-tags/:id', async (req, res, next) => {
  *     responses:
  *       200:
  *         description: Passage note tag deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: number
+ *                   description: Number of deleted tags (1)
+ *       400:
+ *         description: Invalid ID format
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: Passage note tag not found
- *       409:
- *         description: Cannot delete tag (tag is in use)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.delete('/passage-note-tags/:id', async (req, res, next) => {
   try {

--- a/api/router/routes/passage-note-tags.ts
+++ b/api/router/routes/passage-note-tags.ts
@@ -76,7 +76,7 @@ router.get('/passage-note-tags', async (req, res, next) => {
       passageNoteTag.noteCount = await countTagNotes(passageNoteTag);
     }
 
-    return res.send({ data: passageNoteTags } as ApiResponse);
+    return res.json({ data: passageNoteTags } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -123,7 +123,7 @@ router.get('/passage-note-tags/:id', async (req, res, next) => {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
     passageNoteTag.noteCount = await countTagNotes(passageNoteTag);
-    res.send({ data: passageNoteTag.toJSON() } as ApiResponse);
+    res.json({ data: passageNoteTag.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -189,7 +189,7 @@ router.post('/passage-note-tags', async (req, res, next) => {
     }
 
     passageNoteTag.noteCount = 0;
-    res.send({ data: passageNoteTag.toJSON() } as ApiResponse);
+    res.json({ data: passageNoteTag.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -265,7 +265,7 @@ router.put('/passage-note-tags/:id', async (req, res, next) => {
 
     await passageNoteTag.save();
 
-    res.send({ data: passageNoteTag.toJSON() } as ApiResponse);
+    res.json({ data: passageNoteTag.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -310,7 +310,7 @@ router.delete('/passage-note-tags/:id', async (req, res, next) => {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
 
-    res.send({ data: result.deletedCount } as ApiResponse);
+    res.json({ data: result.deletedCount } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/passage-notes.ts
+++ b/api/router/routes/passage-notes.ts
@@ -6,8 +6,8 @@ import useMongooseModels from '../../mongoose/useMongooseModels';
 
 import { QueryFilter, Types } from 'mongoose';
 import { IPassageNote } from '../../mongoose/schemas/PassageNote';
-import { ApiErrorCode, ApiErrorDetailCode } from '../helpers/error-codes';
-import { type ApiResponse } from '../helpers/response';
+import { ApiErrorCode, ApiErrorDetailCode } from '../errors/error-codes';
+import { type ApiResponse } from '../response';
 const router = express.Router();
 
 /**

--- a/api/router/routes/passage-notes.ts
+++ b/api/router/routes/passage-notes.ts
@@ -730,7 +730,7 @@ router.get('/passage-notes/count/books', async (req, res, next) => {
       },
     ]);
 
-    res.send(result[0]);
+    res.send({ data: result[0] });
   }
   catch (error) {
     next(error);

--- a/api/router/routes/passage-notes.ts
+++ b/api/router/routes/passage-notes.ts
@@ -306,7 +306,35 @@ const validateQuery = (query) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PassageNoteList'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/PassageNote'
+ *                 meta:
+ *                   type: object
+ *                   properties:
+ *                     pagination:
+ *                       type: object
+ *                       properties:
+ *                         offset:
+ *                           type: number
+ *                           description: The offset of the results
+ *                         limit:
+ *                           type: number
+ *                           description: The maximum number of results returned
+ *                         size:
+ *                           type: number
+ *                           description: The total number of results available
+ *       400:
+ *         description: Invalid request parameters
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.get('/passage-notes', async (req, res, next) => {
   try {
@@ -428,9 +456,24 @@ router.get('/passage-notes', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PassageNote'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/PassageNote'
+ *       400:
+ *         description: Invalid ID format
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: Passage note not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.get('/passage-notes/:id', async (req, res, next) => {
   try {
@@ -490,9 +533,24 @@ router.get('/passage-notes/:id', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PassageNote'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/PassageNote'
+ *       400:
+ *         description: Validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       409:
  *         description: Cannot create note (invalid tags)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.post('/passage-notes', async (req, res, next) => {
   try {
@@ -563,11 +621,30 @@ router.post('/passage-notes', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/PassageNote'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/PassageNote'
+ *       400:
+ *         description: Invalid ID format or validation error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: Passage note not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       409:
  *         description: Cannot update note (invalid tags)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.put('/passage-notes/:id', async (req, res, next) => {
   try {
@@ -628,8 +705,28 @@ router.put('/passage-notes/:id', async (req, res, next) => {
  *     responses:
  *       200:
  *         description: Passage note deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: number
+ *                   description: Number of deleted notes (1)
+ *       400:
+ *         description: Invalid ID format
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  *       404:
  *         description: Passage note not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.delete('/passage-notes/:id', async (req, res, next) => {
   try {
@@ -668,9 +765,14 @@ router.delete('/passage-notes/:id', async (req, res, next) => {
  *           application/json:
  *             schema:
  *               type: object
- *               additionalProperties:
- *                 type: number
- *               description: Object with Bible book codes as keys and note counts as values
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: object
+ *                   additionalProperties:
+ *                     type: number
+ *                   description: Object with Bible book codes as keys and note counts as values
  */
 // GET passage note book counts
 router.get('/passage-notes/count/books', async (req, res, next) => {

--- a/api/router/routes/passage-notes.ts
+++ b/api/router/routes/passage-notes.ts
@@ -6,6 +6,7 @@ import useMongooseModels from '../../mongoose/useMongooseModels';
 
 import { QueryFilter, Types } from 'mongoose';
 import { IPassageNote } from '../../mongoose/schemas/PassageNote';
+import { type ApiResponse } from '../helpers/response';
 const router = express.Router();
 
 /**
@@ -398,7 +399,7 @@ router.get('/passage-notes', async (req, res, next) => {
       },
     };
 
-    return res.send(response);
+    return res.send(response as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -444,7 +445,7 @@ router.get('/passage-notes/:id', async (req, res, next) => {
     if (!passageNote) {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
-    res.send({ data: passageNote.toJSON() });
+    res.send({ data: passageNote.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -513,7 +514,7 @@ router.post('/passage-notes', async (req, res, next) => {
     }
     await passageNote.save();
 
-    res.send({ data: passageNote.toJSON() });
+    res.send({ data: passageNote.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -601,7 +602,7 @@ router.put('/passage-notes/:id', async (req, res, next) => {
     }
     await passageNote.save();
 
-    res.send({ data: passageNote.toJSON() });
+    res.send({ data: passageNote.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -644,7 +645,7 @@ router.delete('/passage-notes/:id', async (req, res, next) => {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
 
-    res.send({ data: result.deletedCount });
+    res.send({ data: result.deletedCount } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -730,7 +731,7 @@ router.get('/passage-notes/count/books', async (req, res, next) => {
       },
     ]);
 
-    res.send({ data: result[0] });
+    res.send({ data: result[0] } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/passage-notes.ts
+++ b/api/router/routes/passage-notes.ts
@@ -399,7 +399,7 @@ router.get('/passage-notes', async (req, res, next) => {
       },
     };
 
-    return res.send(response as ApiResponse);
+    return res.json(response as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -445,7 +445,7 @@ router.get('/passage-notes/:id', async (req, res, next) => {
     if (!passageNote) {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
-    res.send({ data: passageNote.toJSON() } as ApiResponse);
+    res.json({ data: passageNote.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -514,7 +514,7 @@ router.post('/passage-notes', async (req, res, next) => {
     }
     await passageNote.save();
 
-    res.send({ data: passageNote.toJSON() } as ApiResponse);
+    res.json({ data: passageNote.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -602,7 +602,7 @@ router.put('/passage-notes/:id', async (req, res, next) => {
     }
     await passageNote.save();
 
-    res.send({ data: passageNote.toJSON() } as ApiResponse);
+    res.json({ data: passageNote.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -645,7 +645,7 @@ router.delete('/passage-notes/:id', async (req, res, next) => {
       return res.status(404).send({ error: { error: { message: 'Not Found' } } });
     }
 
-    res.send({ data: result.deletedCount } as ApiResponse);
+    res.json({ data: result.deletedCount } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -731,7 +731,7 @@ router.get('/passage-notes/count/books', async (req, res, next) => {
       },
     ]);
 
-    res.send({ data: result[0] } as ApiResponse);
+    res.json({ data: result[0] } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/passage-notes.ts
+++ b/api/router/routes/passage-notes.ts
@@ -3,7 +3,6 @@ import { ObjectId } from 'mongodb';
 import authCurrentUser from '../helpers/authCurrentUser';
 import { Bible } from '@mybiblelog/shared';
 import useMongooseModels from '../../mongoose/useMongooseModels';
-
 import { QueryFilter, Types } from 'mongoose';
 import { IPassageNote } from '../../mongoose/schemas/PassageNote';
 import { ApiErrorDetailCode } from '../errors/error-codes';

--- a/api/router/routes/reminders.ts
+++ b/api/router/routes/reminders.ts
@@ -1,8 +1,8 @@
 import express from 'express';
 import authCurrentUser from '../helpers/authCurrentUser';
 import useMongooseModels from '../../mongoose/useMongooseModels';
-import { ApiErrorCode } from '../errors/error-codes';
 import { type ApiResponse } from '../response';
+import { NotFoundError } from '../errors/http-errors';
 
 const router = express.Router();
 
@@ -208,12 +208,12 @@ router.put('/reminders/daily-reminder/unsubscribe/:code', async (req, res, next)
 
   const reminder = await DailyReminder.findOne({ unsubscribeCode: code });
   if (!reminder) {
-    return res.status(404).send({ error: { code: ApiErrorCode.NotFound } } satisfies ApiResponse);
+    throw new NotFoundError();
   }
 
   const user = await User.findOne({ _id: reminder.owner });
   if (!user) {
-    return res.status(404).send({ error: { code: ApiErrorCode.NotFound } } satisfies ApiResponse);
+    throw new NotFoundError();
   }
 
   reminder.active = false;

--- a/api/router/routes/reminders.ts
+++ b/api/router/routes/reminders.ts
@@ -85,7 +85,12 @@ const getUserReminder = async (currentUser) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/DailyReminder'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/DailyReminder'
  */
 router.get('/reminders/daily-reminder', async (req, res, next) => {
   try {
@@ -131,7 +136,12 @@ router.get('/reminders/daily-reminder', async (req, res, next) => {
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/DailyReminder'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/DailyReminder'
  */
 router.put('/reminders/daily-reminder', async (req, res, next) => {
   try {
@@ -176,13 +186,21 @@ router.put('/reminders/daily-reminder', async (req, res, next) => {
  *           application/json:
  *             schema:
  *               type: object
+ *               required:
+ *                 - data
  *               properties:
- *                 error:
- *                   type: boolean
- *                   description: Whether there was an error
- *                 email:
- *                   type: string
- *                   description: The email of the user who was unsubscribed
+ *                 data:
+ *                   type: object
+ *                   properties:
+ *                     email:
+ *                       type: string
+ *                       description: The email of the user who was unsubscribed
+ *       404:
+ *         description: Reminder or user not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.put('/reminders/daily-reminder/unsubscribe/:code', async (req, res, next) => {
   const { code } = req.params;

--- a/api/router/routes/reminders.ts
+++ b/api/router/routes/reminders.ts
@@ -90,7 +90,7 @@ router.get('/reminders/daily-reminder', async (req, res, next) => {
   try {
     const currentUser = await authCurrentUser(req);
     const reminder = await getUserReminder(currentUser);
-    return res.send({ data: reminder.toJSON() } as ApiResponse);
+    return res.json({ data: reminder.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -148,7 +148,7 @@ router.put('/reminders/daily-reminder', async (req, res, next) => {
       }
     });
     await reminder.save();
-    res.send({ data: reminder.toJSON() } as ApiResponse);
+    res.json({ data: reminder.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -200,7 +200,7 @@ router.put('/reminders/daily-reminder/unsubscribe/:code', async (req, res, next)
   reminder.active = false;
   await reminder.save();
 
-  return res.send({ data: { email: user.email } } as ApiResponse);
+  return res.json({ data: { email: user.email } } as ApiResponse);
 });
 
 export default router;

--- a/api/router/routes/reminders.ts
+++ b/api/router/routes/reminders.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import authCurrentUser from '../helpers/authCurrentUser';
 import useMongooseModels from '../../mongoose/useMongooseModels';
+import { type ApiResponse } from '../helpers/response';
 
 const router = express.Router();
 
@@ -89,7 +90,7 @@ router.get('/reminders/daily-reminder', async (req, res, next) => {
   try {
     const currentUser = await authCurrentUser(req);
     const reminder = await getUserReminder(currentUser);
-    return res.send({ data: reminder.toJSON() });
+    return res.send({ data: reminder.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -147,7 +148,7 @@ router.put('/reminders/daily-reminder', async (req, res, next) => {
       }
     });
     await reminder.save();
-    res.send({ data: reminder.toJSON() });
+    res.send({ data: reminder.toJSON() } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -199,7 +200,7 @@ router.put('/reminders/daily-reminder/unsubscribe/:code', async (req, res, next)
   reminder.active = false;
   await reminder.save();
 
-  return res.send({ data: { email: user.email } });
+  return res.send({ data: { email: user.email } } as ApiResponse);
 });
 
 export default router;

--- a/api/router/routes/reminders.ts
+++ b/api/router/routes/reminders.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import authCurrentUser from '../helpers/authCurrentUser';
 import useMongooseModels from '../../mongoose/useMongooseModels';
+import { ApiErrorCode } from '../helpers/error-codes';
 import { type ApiResponse } from '../helpers/response';
 
 const router = express.Router();
@@ -90,7 +91,7 @@ router.get('/reminders/daily-reminder', async (req, res, next) => {
   try {
     const currentUser = await authCurrentUser(req);
     const reminder = await getUserReminder(currentUser);
-    return res.json({ data: reminder.toJSON() } as ApiResponse);
+    return res.json({ data: reminder.toJSON() } satisfies ApiResponse);
   }
   catch (error) {
     next(error);
@@ -148,7 +149,7 @@ router.put('/reminders/daily-reminder', async (req, res, next) => {
       }
     });
     await reminder.save();
-    res.json({ data: reminder.toJSON() } as ApiResponse);
+    res.json({ data: reminder.toJSON() } satisfies ApiResponse);
   }
   catch (error) {
     next(error);
@@ -189,18 +190,18 @@ router.put('/reminders/daily-reminder/unsubscribe/:code', async (req, res, next)
 
   const reminder = await DailyReminder.findOne({ unsubscribeCode: code });
   if (!reminder) {
-    return res.status(404).send({ error: { error: { message: 'Not Found' } } });
+    return res.status(404).send({ error: { code: ApiErrorCode.NotFound } } satisfies ApiResponse);
   }
 
   const user = await User.findOne({ _id: reminder.owner });
   if (!user) {
-    return res.status(404).send({ error: { error: { message: 'Not Found' } } });
+    return res.status(404).send({ error: { code: ApiErrorCode.NotFound } } satisfies ApiResponse);
   }
 
   reminder.active = false;
   await reminder.save();
 
-  return res.json({ data: { email: user.email } } as ApiResponse);
+  return res.json({ data: { email: user.email } } satisfies ApiResponse);
 });
 
 export default router;

--- a/api/router/routes/reminders.ts
+++ b/api/router/routes/reminders.ts
@@ -1,8 +1,8 @@
 import express from 'express';
 import authCurrentUser from '../helpers/authCurrentUser';
 import useMongooseModels from '../../mongoose/useMongooseModels';
-import { ApiErrorCode } from '../helpers/error-codes';
-import { type ApiResponse } from '../helpers/response';
+import { ApiErrorCode } from '../errors/error-codes';
+import { type ApiResponse } from '../response';
 
 const router = express.Router();
 

--- a/api/router/routes/reminders.ts
+++ b/api/router/routes/reminders.ts
@@ -89,7 +89,7 @@ router.get('/reminders/daily-reminder', async (req, res, next) => {
   try {
     const currentUser = await authCurrentUser(req);
     const reminder = await getUserReminder(currentUser);
-    return res.send(reminder.toJSON());
+    return res.send({ data: reminder.toJSON() });
   }
   catch (error) {
     next(error);
@@ -147,7 +147,7 @@ router.put('/reminders/daily-reminder', async (req, res, next) => {
       }
     });
     await reminder.save();
-    res.send(reminder.toJSON());
+    res.send({ data: reminder.toJSON() });
   }
   catch (error) {
     next(error);
@@ -188,25 +188,18 @@ router.put('/reminders/daily-reminder/unsubscribe/:code', async (req, res, next)
 
   const reminder = await DailyReminder.findOne({ unsubscribeCode: code });
   if (!reminder) {
-    return res.send({
-      error: true,
-    });
+    return res.status(404).send({ error: { error: { message: 'Not Found' } } });
   }
 
   const user = await User.findOne({ _id: reminder.owner });
   if (!user) {
-    return res.send({
-      error: true,
-    });
+    return res.status(404).send({ error: { error: { message: 'Not Found' } } });
   }
 
   reminder.active = false;
   await reminder.save();
 
-  return res.send({
-    error: false,
-    email: user.email,
-  });
+  return res.send({ data: { email: user.email } });
 });
 
 export default router;

--- a/api/router/routes/settings.ts
+++ b/api/router/routes/settings.ts
@@ -2,7 +2,6 @@ import express from 'express';
 import authCurrentUser, { AUTH_COOKIE_NAME } from '../helpers/authCurrentUser';
 import deleteAccount from '../helpers/deleteAccount';
 import { type ApiResponse } from '../response';
-import { UnauthenticatedError } from '../errors/http-errors';
 import { InternalError } from '../errors/internal-error';
 
 const router = express.Router();

--- a/api/router/routes/settings.ts
+++ b/api/router/routes/settings.ts
@@ -59,9 +59,6 @@ const router = express.Router();
 router.get('/settings', async (req, res, next) => {
   try {
     const currentUser = await authCurrentUser(req);
-    if (!currentUser) {
-      throw new UnauthenticatedError();
-    }
     res.json({ data: currentUser.settings } satisfies ApiResponse);
   }
   catch (error) {

--- a/api/router/routes/settings.ts
+++ b/api/router/routes/settings.ts
@@ -93,7 +93,7 @@ router.put('/settings', async (req, res, next) => {
       }
     });
     await currentUser.save();
-    return res.send({ data: currentUser.settings } as ApiResponse);
+    return res.json({ data: currentUser.settings } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -121,7 +121,7 @@ router.put('/settings/delete-account', async (req, res, next) => {
     }
     // clear the auth cookie on account deletion
     res.clearCookie(AUTH_COOKIE_NAME);
-    return res.send({ data: 1 } as ApiResponse);
+    return res.json({ data: 1 } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/settings.ts
+++ b/api/router/routes/settings.ts
@@ -1,6 +1,4 @@
 import express from 'express';
-import status from 'http-status';
-import createError from 'http-errors';
 import authCurrentUser, { AUTH_COOKIE_NAME } from '../helpers/authCurrentUser';
 import deleteAccount from '../helpers/deleteAccount';
 
@@ -48,9 +46,9 @@ router.get('/settings', async (req, res, next) => {
   try {
     const currentUser = await authCurrentUser(req);
     if (!currentUser) {
-      return next(createError(401, 'Unauthorized'));
+      return res.status(401).send({ error: { error: { message: 'Unauthorized' } } });
     }
-    res.json(currentUser.settings);
+    res.json({ data: currentUser.settings });
   }
   catch (error) {
     next(error);
@@ -94,7 +92,7 @@ router.put('/settings', async (req, res, next) => {
       }
     });
     await currentUser.save();
-    return res.sendStatus(status.OK);
+    return res.send({ data: currentUser.settings });
   }
   catch (error) {
     next(error);
@@ -118,11 +116,11 @@ router.put('/settings/delete-account', async (req, res, next) => {
     const currentUser = await authCurrentUser(req);
     const success = await deleteAccount(currentUser.email);
     if (!success) {
-      return next(createError(500, 'Failed to delete account'));
+      return res.status(500).send({ error: { error: { message: 'Failed to delete account' } } });
     }
     // clear the auth cookie on account deletion
     res.clearCookie(AUTH_COOKIE_NAME);
-    return res.sendStatus(status.OK);
+    return res.send({ data: 1 });
   }
   catch (error) {
     next(error);

--- a/api/router/routes/settings.ts
+++ b/api/router/routes/settings.ts
@@ -42,7 +42,18 @@ const router = express.Router();
  *         content:
  *           application/json:
  *             schema:
- *               $ref: '#/components/schemas/UserSettings'
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/UserSettings'
+ *       401:
+ *         description: Unauthorized - User is not authenticated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.get('/settings', async (req, res, next) => {
   try {
@@ -77,6 +88,15 @@ router.get('/settings', async (req, res, next) => {
  *     responses:
  *       200:
  *         description: Settings updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/UserSettings'
  */
 router.put('/settings', async (req, res, next) => {
   try {
@@ -112,6 +132,22 @@ router.put('/settings', async (req, res, next) => {
  *     responses:
  *       200:
  *         description: Account deleted successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               required:
+ *                 - data
+ *               properties:
+ *                 data:
+ *                   type: number
+ *                   description: Number of deleted accounts (1)
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
  */
 router.put('/settings/delete-account', async (req, res, next) => {
   try {

--- a/api/router/routes/settings.ts
+++ b/api/router/routes/settings.ts
@@ -1,8 +1,8 @@
 import express from 'express';
 import authCurrentUser, { AUTH_COOKIE_NAME } from '../helpers/authCurrentUser';
 import deleteAccount from '../helpers/deleteAccount';
-import { ApiErrorCode } from '../helpers/error-codes';
-import { type ApiResponse } from '../helpers/response';
+import { ApiErrorCode } from '../errors/error-codes';
+import { type ApiResponse } from '../response';
 
 const router = express.Router();
 

--- a/api/router/routes/settings.ts
+++ b/api/router/routes/settings.ts
@@ -1,8 +1,9 @@
 import express from 'express';
 import authCurrentUser, { AUTH_COOKIE_NAME } from '../helpers/authCurrentUser';
 import deleteAccount from '../helpers/deleteAccount';
-import { ApiErrorCode } from '../errors/error-codes';
 import { type ApiResponse } from '../response';
+import { UnauthenticatedError } from '../errors/http-errors';
+import { InternalError } from '../errors/internal-error';
 
 const router = express.Router();
 
@@ -59,7 +60,7 @@ router.get('/settings', async (req, res, next) => {
   try {
     const currentUser = await authCurrentUser(req);
     if (!currentUser) {
-      return res.status(401).send({ error: { code: ApiErrorCode.Unauthenticated } } satisfies ApiResponse);
+      throw new UnauthenticatedError();
     }
     res.json({ data: currentUser.settings } satisfies ApiResponse);
   }
@@ -154,7 +155,7 @@ router.put('/settings/delete-account', async (req, res, next) => {
     const currentUser = await authCurrentUser(req);
     const success = await deleteAccount(currentUser.email);
     if (!success) {
-      return res.status(500).send({ error: { code: ApiErrorCode.InternalServerError } } satisfies ApiResponse);
+      throw new InternalError();
     }
     // clear the auth cookie on account deletion
     res.clearCookie(AUTH_COOKIE_NAME);

--- a/api/router/routes/settings.ts
+++ b/api/router/routes/settings.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import authCurrentUser, { AUTH_COOKIE_NAME } from '../helpers/authCurrentUser';
 import deleteAccount from '../helpers/deleteAccount';
+import { type ApiResponse } from '../helpers/response';
 
 const router = express.Router();
 
@@ -48,7 +49,7 @@ router.get('/settings', async (req, res, next) => {
     if (!currentUser) {
       return res.status(401).send({ error: { error: { message: 'Unauthorized' } } });
     }
-    res.json({ data: currentUser.settings });
+    res.json({ data: currentUser.settings } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -92,7 +93,7 @@ router.put('/settings', async (req, res, next) => {
       }
     });
     await currentUser.save();
-    return res.send({ data: currentUser.settings });
+    return res.send({ data: currentUser.settings } as ApiResponse);
   }
   catch (error) {
     next(error);
@@ -120,7 +121,7 @@ router.put('/settings/delete-account', async (req, res, next) => {
     }
     // clear the auth cookie on account deletion
     res.clearCookie(AUTH_COOKIE_NAME);
-    return res.send({ data: 1 });
+    return res.send({ data: 1 } as ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/router/routes/settings.ts
+++ b/api/router/routes/settings.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import authCurrentUser, { AUTH_COOKIE_NAME } from '../helpers/authCurrentUser';
 import deleteAccount from '../helpers/deleteAccount';
+import { ApiErrorCode } from '../helpers/error-codes';
 import { type ApiResponse } from '../helpers/response';
 
 const router = express.Router();
@@ -47,9 +48,9 @@ router.get('/settings', async (req, res, next) => {
   try {
     const currentUser = await authCurrentUser(req);
     if (!currentUser) {
-      return res.status(401).send({ error: { error: { message: 'Unauthorized' } } });
+      return res.status(401).send({ error: { code: ApiErrorCode.Unauthenticated } } satisfies ApiResponse);
     }
-    res.json({ data: currentUser.settings } as ApiResponse);
+    res.json({ data: currentUser.settings } satisfies ApiResponse);
   }
   catch (error) {
     next(error);
@@ -93,7 +94,7 @@ router.put('/settings', async (req, res, next) => {
       }
     });
     await currentUser.save();
-    return res.json({ data: currentUser.settings } as ApiResponse);
+    return res.json({ data: currentUser.settings } satisfies ApiResponse);
   }
   catch (error) {
     next(error);
@@ -117,11 +118,11 @@ router.put('/settings/delete-account', async (req, res, next) => {
     const currentUser = await authCurrentUser(req);
     const success = await deleteAccount(currentUser.email);
     if (!success) {
-      return res.status(500).send({ error: { error: { message: 'Failed to delete account' } } });
+      return res.status(500).send({ error: { code: ApiErrorCode.InternalServerError } } satisfies ApiResponse);
     }
     // clear the auth cookie on account deletion
     res.clearCookie(AUTH_COOKIE_NAME);
-    return res.json({ data: 1 } as ApiResponse);
+    return res.json({ data: 1 } satisfies ApiResponse);
   }
   catch (error) {
     next(error);

--- a/api/services/email/email-queue.ts
+++ b/api/services/email/email-queue.ts
@@ -17,7 +17,7 @@ export function createQueue<T>(sendFn: (job: T) => Promise<void>): { enqueue: (j
 
       try {
         await sendFn(job);
-        console.log('Email sent successfully');
+        console.log('Email queued successfully');
       } catch (err) {
         if (err.statusCode === 429) {
           console.warn('Email provider throttled — retrying in 2s');

--- a/api/services/email/email-service.ts
+++ b/api/services/email/email-service.ts
@@ -23,13 +23,14 @@ const init = async () => {
   const { Email } = await useMongooseModels();
 
   const sendFn = async (params: SendEmailParams): Promise<void> => {
-    let status = 'pending';
+    let status: 'pending' | 'sent' | 'failed' | 'log_only' = 'pending';
 
     // only send email in production
     if (config.nodeEnv === "production") {
       try {
         await sendEmail(params);
         status = 'sent';
+        console.log('Email sent successfully');
       }
       catch (error) {
         status = 'failed';
@@ -37,6 +38,7 @@ const init = async () => {
       }
     } else {
       status = 'log_only';
+      console.log('Email logged successfully');
     }
 
     // record email, but do not block with `await`

--- a/api/test/admin.test.ts
+++ b/api/test/admin.test.ts
@@ -116,7 +116,7 @@ describe('admin.test.js', () => {
         expect(response.status).toBe(400);
         expect(response.body).toHaveProperty('error');
         expect(response.body).not.toHaveProperty('data');
-        expect(response.body.error.error.message).toBe('You cannot delete your own admin account');
+        expect(response.body.error.code).toBe('invalid_request');
       }
       finally {
         await deleteTestUser(admin);

--- a/api/test/admin.test.ts
+++ b/api/test/admin.test.ts
@@ -114,8 +114,9 @@ describe('admin.test.js', () => {
           .delete(`/api/admin/users/${admin.email}`)
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(400);
-        expect(response.body.errors).toBeDefined();
-        expect(response.body.errors.message).toBe('You cannot delete your own admin account');
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
+        expect(response.body.error.error.message).toBe('You cannot delete your own admin account');
       }
       finally {
         await deleteTestUser(admin);
@@ -137,12 +138,17 @@ describe('admin.test.js', () => {
           .delete(`/api/admin/users/${testUser.email}`)
           .set('Authorization', `Bearer ${admin.token}`);
         expect(deleteResponse.status).toBe(200);
+        expect(deleteResponse.body).toHaveProperty('data');
+        expect(deleteResponse.body).not.toHaveProperty('error');
+        expect(deleteResponse.body.data).toBe(1);
 
         // Verify the user no longer exists
         const getDeletedUserResponse = await requestApi
           .get(`/api/admin/users/${testUser.email}`)
           .set('Authorization', `Bearer ${admin.token}`);
         expect(getDeletedUserResponse.status).toBe(404);
+        expect(getDeletedUserResponse.body).toHaveProperty('error');
+        expect(getDeletedUserResponse.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(admin);
@@ -158,12 +164,14 @@ describe('admin.test.js', () => {
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        expect(Array.isArray(response.body)).toBe(true);
-        expect(response.body.length).toBe(7); // Last 7 days
-        expect(response.body[0]).toHaveProperty('date');
-        expect(response.body[0]).toHaveProperty('newUserAccounts');
-        expect(response.body[0]).toHaveProperty('usersWithLogEntry');
-        expect(response.body[0]).toHaveProperty('usersWithNote');
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.data.length).toBe(7); // Last 7 days
+        expect(response.body.data[0]).toHaveProperty('date');
+        expect(response.body.data[0]).toHaveProperty('newUserAccounts');
+        expect(response.body.data[0]).toHaveProperty('usersWithLogEntry');
+        expect(response.body.data[0]).toHaveProperty('usersWithNote');
       }
       finally {
         await deleteTestUser(admin);
@@ -179,7 +187,7 @@ describe('admin.test.js', () => {
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
         const today = dayjs().format('YYYY-MM-DD');
-        const initialCount = initialResponse.body.find(d => d.date === today).usersWithLogEntry;
+        const initialCount = initialResponse.body.data.find(d => d.date === today).usersWithLogEntry;
 
         // Add a log entry
         await requestApi
@@ -195,7 +203,7 @@ describe('admin.test.js', () => {
         const updatedResponse = await requestApi
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
-        const updatedCount = updatedResponse.body.find(d => d.date === today).usersWithLogEntry;
+        const updatedCount = updatedResponse.body.data.find(d => d.date === today).usersWithLogEntry;
 
         expect(updatedCount).toBe(initialCount + 1);
       }
@@ -214,7 +222,7 @@ describe('admin.test.js', () => {
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
         const yesterday = dayjs().subtract(1, 'day').format('YYYY-MM-DD');
-        const initialCount = initialResponse.body.find(d => d.date === yesterday).usersWithLogEntry;
+        const initialCount = initialResponse.body.data.find(d => d.date === yesterday).usersWithLogEntry;
 
         // Add a log entry
         await requestApi
@@ -230,7 +238,7 @@ describe('admin.test.js', () => {
         const updatedResponse = await requestApi
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
-        const updatedCount = updatedResponse.body.find(d => d.date === yesterday).usersWithLogEntry;
+        const updatedCount = updatedResponse.body.data.find(d => d.date === yesterday).usersWithLogEntry;
 
         expect(updatedCount).toBe(initialCount + 1);
       }
@@ -249,7 +257,7 @@ describe('admin.test.js', () => {
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
         const today = dayjs().format('YYYY-MM-DD');
-        const initialCount = initialResponse.body.find(d => d.date === today).usersWithLogEntry;
+        const initialCount = initialResponse.body.data.find(d => d.date === today).usersWithLogEntry;
 
         // Add two log entries
         await requestApi
@@ -274,7 +282,7 @@ describe('admin.test.js', () => {
         const updatedResponse = await requestApi
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
-        const updatedCount = updatedResponse.body.find(d => d.date === today).usersWithLogEntry;
+        const updatedCount = updatedResponse.body.data.find(d => d.date === today).usersWithLogEntry;
 
         expect(updatedCount).toBe(initialCount + 1);
       }
@@ -309,7 +317,7 @@ describe('admin.test.js', () => {
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
 
-        expect(updatedResponse.body).toEqual(initialResponse.body);
+        expect(updatedResponse.body.data).toEqual(initialResponse.body.data);
       }
       finally {
         await deleteTestUser(testUser);
@@ -326,7 +334,7 @@ describe('admin.test.js', () => {
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
         const today = dayjs().format('YYYY-MM-DD');
-        const initialCount = initialResponse.body.find(d => d.date === today).usersWithNote;
+        const initialCount = initialResponse.body.data.find(d => d.date === today).usersWithNote;
 
         // Add a note
         await requestApi
@@ -341,7 +349,7 @@ describe('admin.test.js', () => {
         const updatedResponse = await requestApi
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
-        const updatedCount = updatedResponse.body.find(d => d.date === today).usersWithNote;
+        const updatedCount = updatedResponse.body.data.find(d => d.date === today).usersWithNote;
 
         expect(updatedCount).toBe(initialCount + 1);
       }
@@ -360,7 +368,7 @@ describe('admin.test.js', () => {
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
         const today = dayjs().format('YYYY-MM-DD');
-        const initialCount = initialResponse.body.find(d => d.date === today).usersWithNote;
+        const initialCount = initialResponse.body.data.find(d => d.date === today).usersWithNote;
 
         // Add two notes
         await requestApi
@@ -383,7 +391,7 @@ describe('admin.test.js', () => {
         const updatedResponse = await requestApi
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
-        const updatedCount = updatedResponse.body.find(d => d.date === today).usersWithNote;
+        const updatedCount = updatedResponse.body.data.find(d => d.date === today).usersWithNote;
 
         expect(updatedCount).toBe(initialCount + 1);
       }
@@ -402,7 +410,7 @@ describe('admin.test.js', () => {
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
         const today = dayjs().format('YYYY-MM-DD');
-        const initialCount = initialResponse.body.find(d => d.date === today).newUserAccounts;
+        const initialCount = initialResponse.body.data.find(d => d.date === today).newUserAccounts;
 
         // Create a new user
         testUser = await createTestUser();
@@ -411,7 +419,7 @@ describe('admin.test.js', () => {
         const updatedResponse = await requestApi
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
-        const updatedCount = updatedResponse.body.find(d => d.date === today).newUserAccounts;
+        const updatedCount = updatedResponse.body.data.find(d => d.date === today).newUserAccounts;
 
         expect(updatedCount).toBe(initialCount + 1);
       }
@@ -430,7 +438,7 @@ describe('admin.test.js', () => {
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
         const today = dayjs().format('YYYY-MM-DD');
-        const initialCount = initialResponse.body.find(d => d.date === today).newUserAccounts;
+        const initialCount = initialResponse.body.data.find(d => d.date === today).newUserAccounts;
 
         // Delete the user
         await requestApi
@@ -441,7 +449,7 @@ describe('admin.test.js', () => {
         const updatedResponse = await requestApi
           .get('/api/admin/reports/user-engagement/past-week')
           .set('Authorization', `Bearer ${admin.token}`);
-        const updatedCount = updatedResponse.body.find(d => d.date === today).newUserAccounts;
+        const updatedCount = updatedResponse.body.data.find(d => d.date === today).newUserAccounts;
 
         expect(updatedCount).toBe(initialCount - 1);
       }
@@ -460,14 +468,17 @@ describe('admin.test.js', () => {
           .get('/api/admin/users')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        expect(response.body).toHaveProperty('results');
-        expect(response.body).toHaveProperty('offset');
-        expect(response.body).toHaveProperty('limit');
-        expect(response.body).toHaveProperty('size');
-        expect(Array.isArray(response.body.results)).toBe(true);
-        expect(response.body.results.length).toBeGreaterThan(0);
-        expect(response.body.results[0]).toHaveProperty('email');
-        expect(response.body.results[0]).toHaveProperty('createdAt');
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).toHaveProperty('meta');
+        expect(response.body).not.toHaveProperty('error');
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.data.length).toBeGreaterThan(0);
+        expect(response.body.data[0]).toHaveProperty('email');
+        expect(response.body.data[0]).toHaveProperty('createdAt');
+        expect(response.body.meta).toHaveProperty('pagination');
+        expect(response.body.meta.pagination).toHaveProperty('offset');
+        expect(response.body.meta.pagination).toHaveProperty('limit');
+        expect(response.body.meta.pagination).toHaveProperty('size');
       }
       finally {
         await deleteTestUser(testUser);
@@ -483,8 +494,10 @@ describe('admin.test.js', () => {
           .get(`/api/admin/users?searchText=${testUser.email}`)
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.results.length).toBe(1);
-        expect(response.body.results[0].email).toBe(testUser.email);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.length).toBe(1);
+        expect(response.body.data[0].email).toBe(testUser.email);
       }
       finally {
         await deleteTestUser(testUser);
@@ -501,8 +514,10 @@ describe('admin.test.js', () => {
           .get('/api/admin/users?sortOn=email&sortDirection=ascending')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.results.length).toBeGreaterThan(1);
-        const emails = response.body.results.map(user => user.email);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.length).toBeGreaterThan(1);
+        const emails = response.body.data.map(user => user.email);
         const sortedEmails = [...emails].sort();
         expect(emails).toEqual(sortedEmails);
       }
@@ -522,8 +537,10 @@ describe('admin.test.js', () => {
           .get('/api/admin/users?sortOn=email&sortDirection=descending')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.results.length).toBeGreaterThan(1);
-        const emails = response.body.results.map(user => user.email);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.length).toBeGreaterThan(1);
+        const emails = response.body.data.map(user => user.email);
         const sortedEmails = [...emails].sort().reverse();
         expect(emails).toEqual(sortedEmails);
       }
@@ -543,8 +560,10 @@ describe('admin.test.js', () => {
           .get('/api/admin/users?sortOn=createdAt&sortDirection=ascending')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.results.length).toBeGreaterThan(1);
-        const createdAt = response.body.results.map(user => user.createdAt);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.length).toBeGreaterThan(1);
+        const createdAt = response.body.data.map(user => user.createdAt);
         const sortedCreatedAt = [...createdAt].sort();
         expect(createdAt).toEqual(sortedCreatedAt);
       }
@@ -564,8 +583,10 @@ describe('admin.test.js', () => {
           .get('/api/admin/users?sortOn=createdAt&sortDirection=descending')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.results.length).toBeGreaterThan(1);
-        const createdAt = response.body.results.map(user => user.createdAt);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.length).toBeGreaterThan(1);
+        const createdAt = response.body.data.map(user => user.createdAt);
         const sortedCreatedAt = [...createdAt].sort().reverse();
         expect(createdAt).toEqual(sortedCreatedAt);
       }
@@ -585,7 +606,9 @@ describe('admin.test.js', () => {
           .get('/api/admin/users?limit=1')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.results.length).toBe(1);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.length).toBe(1);
       }
       finally {
         await deleteTestUser(testUser1);
@@ -604,16 +627,20 @@ describe('admin.test.js', () => {
           .get('/api/admin/users')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        const initialResults = response.body.results;
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        const initialResults = response.body.data;
 
         // Get offset results
         const updatedResponse = await requestApi
           .get('/api/admin/users?offset=1')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(updatedResponse.status).toBe(200);
+        expect(updatedResponse.body).toHaveProperty('data');
+        expect(updatedResponse.body).not.toHaveProperty('error');
 
         // Expect to skip the first user
-        expect(updatedResponse.body.results[0].email).toBe(initialResults[1].email);
+        expect(updatedResponse.body.data[0].email).toBe(initialResults[1].email);
       }
       finally {
         await deleteTestUser(testUser1);
@@ -631,8 +658,10 @@ describe('admin.test.js', () => {
           .get('/api/admin/users?size=true')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        expect(response.body).toHaveProperty('size');
-        size = response.body.size;
+        expect(response.body).toHaveProperty('meta');
+        expect(response.body.meta).toHaveProperty('pagination');
+        expect(response.body.meta.pagination).toHaveProperty('size');
+        size = response.body.meta.pagination.size;
 
         // Create a new user
         testUser = await createTestUser();
@@ -642,8 +671,10 @@ describe('admin.test.js', () => {
           .get('/api/admin/users?size=true')
           .set('Authorization', `Bearer ${admin.token}`);
         expect(updatedResponse.status).toBe(200);
-        expect(updatedResponse.body).toHaveProperty('size');
-        expect(updatedResponse.body.size).toBe(size + 1);
+        expect(updatedResponse.body).toHaveProperty('meta');
+        expect(updatedResponse.body.meta).toHaveProperty('pagination');
+        expect(updatedResponse.body.meta.pagination).toHaveProperty('size');
+        expect(updatedResponse.body.meta.pagination.size).toBe(size + 1);
       }
       finally {
         await deleteTestUser(testUser);
@@ -680,8 +711,10 @@ describe('admin.test.js', () => {
           .get(`/api/admin/users/${testUser.email}`)
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
-        expect(response.body).toHaveProperty('email');
-        expect(response.body.email).toBe(testUser.email);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data).toHaveProperty('email');
+        expect(response.body.data.email).toBe(testUser.email);
       }
       finally {
         await deleteTestUser(testUser);
@@ -718,22 +751,26 @@ describe('admin.test.js', () => {
           .get(`/api/admin/users/${testUser.email}/login`)
           .set('Authorization', `Bearer ${admin.token}`);
         expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
         // expect token in response body
-        expect(response.body).toHaveProperty('token');
-        expect(typeof response.body.token).toBe('string');
+        expect(response.body.data).toHaveProperty('token');
+        expect(typeof response.body.data.token).toBe('string');
         // expect cookie to be set in header
         expect(response.headers['set-cookie']).toBeDefined();
         expect(response.headers['set-cookie']?.[0]).toContain('auth_token=');
 
         // Verify the token can be used to perform authenticated requests
-        const token = response.body.token;
+        const token = response.body.data.token;
         const userResponse = await requestApi
           .get('/api/auth/user')
           .set('Authorization', `Bearer ${token}`);
         expect(userResponse.status).toBe(200);
-        expect(userResponse.body).toHaveProperty('user');
-        expect(userResponse.body.user).not.toBeNull();
-        expect(userResponse.body.user.email).toBe(testUser.email);
+        expect(userResponse.body).toHaveProperty('data');
+        expect(userResponse.body).not.toHaveProperty('error');
+        expect(userResponse.body.data).toHaveProperty('user');
+        expect(userResponse.body.data.user).not.toBeNull();
+        expect(userResponse.body.data.user.email).toBe(testUser.email);
       }
       finally {
         await deleteTestUser(testUser);

--- a/api/test/auth.test.ts
+++ b/api/test/auth.test.ts
@@ -26,13 +26,9 @@ describe('Auth routes', () => {
     expect(res.headers['set-cookie']).toBeUndefined();
     expect(res.body).toHaveProperty('error');
     expect(res.body).not.toHaveProperty('data');
-    expect(res.body.error).toHaveProperty('errors');
-    expect(res.body.error.errors).toEqual({
-      _form: {
-        code: 'api_error.invalid_login',
-        field: '_form',
-        properties: {},
-      },
+    expect(res.body.error).toEqual({
+      code: 'validation_error',
+      errors: [{ field: null, code: 'invalid_login' }],
     });
   });
 
@@ -133,19 +129,11 @@ describe('Auth routes', () => {
           locale: 'en',
         });
       expect(response.status).toBe(422);
-      expect(response.body.errors).toEqual({
-        email: {
-          field: 'email',
-          code: 'api_error.review',
-          properties: {
-            length: 13,
-            message: 'is invalid',
-            path: 'email',
-            regexp: {},
-            type: 'regexp',
-            value: 'invalid-email',
-          },
-        },
+      expect(response.body).toHaveProperty('error');
+      expect(response.body).not.toHaveProperty('data');
+      expect(response.body.error).toEqual({
+        code: 'validation_error',
+        errors: [{ field: 'email', code: 'review', properties: {} }],
       });
     });
 
@@ -169,18 +157,11 @@ describe('Auth routes', () => {
 
       // Assert
       expect(response.statusCode).toBe(422);
-      expect(response.body.errors).toEqual({
-        email: {
-          code: 'api_error.unique',
-          field: 'email',
-          properties: {
-            length: 42,
-            message: `Error, expected \`email\` to be unique. Value: \`${truncatedEmail(testUser.email)}\``,
-            path: 'email',
-            type: 'unique',
-            value: truncatedEmail(testUser.email),
-          },
-        },
+      expect(response.body).toHaveProperty('error');
+      expect(response.body).not.toHaveProperty('data');
+      expect(response.body.error).toEqual({
+        code: 'validation_error',
+        errors: [{ field: 'email', code: 'email_in_use' }],
       });
 
       // Cleanup
@@ -199,19 +180,13 @@ describe('Auth routes', () => {
           locale: 'en',
         });
       expect(response.status).toBe(422);
-      expect(response.body.errors).toEqual({
-        password: {
+      expect(response.body.error).toEqual({
+        code: 'validation_error',
+        errors: [{
           field: 'password',
-          code: 'api_error.min_length',
-          properties: {
-            length: 3,
-            message: 'Path `password` (`123`, length 3) is shorter than the minimum allowed length (8).',
-            minlength: 8,
-            path: 'password',
-            type: 'minlength',
-            value: '123',
-          },
-        },
+          code: 'min_length',
+          properties: { minlength: 8 },
+        }],
       });
     });
 
@@ -350,7 +325,8 @@ describe('Auth routes', () => {
       expect(response.body).toHaveProperty('error');
       expect(response.body).not.toHaveProperty('data');
       expect(response.body.error).toEqual({
-        currentPassword: { field: 'currentPassword', code: 'api_error.password_incorrect', properties: {} }
+        code: 'validation_error',
+        errors: [{ field: 'currentPassword', code: 'password_incorrect' }],
       });
 
       // Cleanup
@@ -404,8 +380,10 @@ describe('Auth routes', () => {
       expect(response.statusCode).toBe(422);
       expect(response.body).toHaveProperty('error');
       expect(response.body).not.toHaveProperty('data');
-      expect(response.body.error).toHaveProperty('errors');
-      expect(response.body.error.errors).toHaveProperty('email');
+      expect(response.body.error).toEqual({
+        code: 'validation_error',
+        errors: [{ field: 'email', code: 'account_not_found' }],
+      });
     });
   });
 
@@ -451,7 +429,7 @@ describe('Auth routes', () => {
       expect(res.statusCode).toBe(400);
       expect(res.body).toHaveProperty('error');
       expect(res.body).not.toHaveProperty('data');
-      expect(res.body.error).toHaveProperty('errors');
+      expect(res.body.error.code).toBe('invalid_request');
     });
 
     // Note: A full test that verifies token and cookie would require mocking

--- a/api/test/auth.test.ts
+++ b/api/test/auth.test.ts
@@ -29,7 +29,7 @@ describe('Auth routes', () => {
     expect(res.body.error).toHaveProperty('errors');
     expect(res.body.error.errors).toEqual({
       _form: {
-        kind: 'api_error.invalid_login',
+        code: 'api_error.invalid_login',
         field: '_form',
         properties: {},
       },
@@ -136,7 +136,7 @@ describe('Auth routes', () => {
       expect(response.body.errors).toEqual({
         email: {
           field: 'email',
-          kind: 'api_error.review',
+          code: 'api_error.review',
           properties: {
             length: 13,
             message: 'is invalid',
@@ -171,7 +171,7 @@ describe('Auth routes', () => {
       expect(response.statusCode).toBe(422);
       expect(response.body.errors).toEqual({
         email: {
-          kind: 'api_error.unique',
+          code: 'api_error.unique',
           field: 'email',
           properties: {
             length: 42,
@@ -202,7 +202,7 @@ describe('Auth routes', () => {
       expect(response.body.errors).toEqual({
         password: {
           field: 'password',
-          kind: 'api_error.min_length',
+          code: 'api_error.min_length',
           properties: {
             length: 3,
             message: 'Path `password` (`123`, length 3) is shorter than the minimum allowed length (8).',
@@ -350,7 +350,7 @@ describe('Auth routes', () => {
       expect(response.body).toHaveProperty('error');
       expect(response.body).not.toHaveProperty('data');
       expect(response.body.error).toEqual({
-        currentPassword: { field: 'currentPassword', kind: 'api_error.password_incorrect', properties: {} }
+        currentPassword: { field: 'currentPassword', code: 'api_error.password_incorrect', properties: {} }
       });
 
       // Cleanup

--- a/api/test/error-handling.test.ts
+++ b/api/test/error-handling.test.ts
@@ -7,9 +7,8 @@ describe('Error Handling', () => {
       const response = await requestApi.get('/api/non-existent-route');
       expect(response.status).toBe(404);
       expect(response.body).toEqual({
-        errors: {
-          error: { message: 'Not Found' },
-          message: 'Not Found',
+        error: {
+          code: 'not_found',
         },
       });
     });

--- a/api/test/feedback.test.ts
+++ b/api/test/feedback.test.ts
@@ -14,6 +14,15 @@ describe('Feedback routes', () => {
 
     // Assert
     expect(res.statusCode).toBe(201);
+    expect(res.body).toHaveProperty('data');
+    expect(res.body).not.toHaveProperty('error');
+    expect(res.body.data).toHaveProperty('ip');
+    expect(res.body.data).toHaveProperty('owner');
+    expect(res.body.data).toHaveProperty('email');
+    expect(res.body.data).toHaveProperty('kind');
+    expect(res.body.data).toHaveProperty('message');
+    expect(res.body.data).toHaveProperty('createdAt');
+    expect(res.body.data).toHaveProperty('updatedAt');
   });
 
   test('POST /api/feedback (authenticated user)', async () => {
@@ -32,6 +41,15 @@ describe('Feedback routes', () => {
 
     // Assert
     expect(res.statusCode).toBe(201);
+    expect(res.body).toHaveProperty('data');
+    expect(res.body).not.toHaveProperty('error');
+    expect(res.body.data).toHaveProperty('ip');
+    expect(res.body.data).toHaveProperty('owner');
+    expect(res.body.data).toHaveProperty('email');
+    expect(res.body.data).toHaveProperty('kind');
+    expect(res.body.data).toHaveProperty('message');
+    expect(res.body.data).toHaveProperty('createdAt');
+    expect(res.body.data).toHaveProperty('updatedAt');
 
     // Cleanup
     await deleteTestUser(testUser);

--- a/api/test/helpers.ts
+++ b/api/test/helpers.ts
@@ -63,10 +63,10 @@ async function createTestUser({ locale = 'en', isAdmin = false }: CreateTestUser
   }
 
   return {
-    id: loginResponse.body.id,
+    id: loginResponse.body.data.id,
     email,
     password,
-    token: loginResponse.body.token,
+    token: loginResponse.body.data.token,
   };
 }
 

--- a/api/test/log-entries.test.ts
+++ b/api/test/log-entries.test.ts
@@ -25,7 +25,9 @@ describe('log-entries.test.js', () => {
           .get('/api/log-entries')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(Array.isArray(response.body)).toBe(true);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(Array.isArray(response.body.data)).toBe(true);
       }
       finally {
         await deleteTestUser(testUser);
@@ -39,6 +41,8 @@ describe('log-entries.test.js', () => {
           .get('/api/log-entries?startDate=invalid')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -52,6 +56,8 @@ describe('log-entries.test.js', () => {
           .get('/api/log-entries?startDate=2024-01-01&endDate=invalid')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -77,8 +83,10 @@ describe('log-entries.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`);
 
         expect(response.status).toBe(200);
-        expect(response.body.length).toBe(1);
-        expect(response.body[0].id).toBe(entry2.body.id);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.length).toBe(1);
+        expect(response.body.data[0].id).toBe(entry2.body.data.id);
       }
       finally {
         await deleteTestUser(testUser);
@@ -104,8 +112,10 @@ describe('log-entries.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`);
 
         expect(response.status).toBe(200);
-        expect(response.body.length).toBe(1);
-        expect(response.body[0].id).toBe(entry1.body.id);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.length).toBe(1);
+        expect(response.body.data[0].id).toBe(entry1.body.data.id);
       }
       finally {
         await deleteTestUser(testUser);
@@ -131,7 +141,9 @@ describe('log-entries.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`);
 
         expect(response.status).toBe(200);
-        expect(response.body.length).toBe(2);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.length).toBe(2);
       }
       finally {
         await deleteTestUser(testUser);
@@ -158,7 +170,9 @@ describe('log-entries.test.js', () => {
         .set('Authorization', `Bearer ${testUser.token}`);
 
       expect(response.status).toBe(200);
-      expect(response.body.length).toBe(2);
+      expect(response.body).toHaveProperty('data');
+      expect(response.body).not.toHaveProperty('error');
+      expect(response.body.data.length).toBe(2);
     }
     finally {
       await deleteTestUser(testUser);
@@ -181,6 +195,8 @@ describe('log-entries.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({});
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -195,6 +211,8 @@ describe('log-entries.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(invalidLogEntry1);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -209,6 +227,8 @@ describe('log-entries.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(invalidLogEntry1);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -223,6 +243,8 @@ describe('log-entries.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(invalidLogEntry2);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -237,6 +259,8 @@ describe('log-entries.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(invalidLogEntry3);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -252,7 +276,9 @@ describe('log-entries.test.js', () => {
           .send(logEntry1);
 
         expect(response.status).toBe(200);
-        expect(response.body).toMatchObject({
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data).toMatchObject({
           date: logEntry1.date,
           startVerseId: logEntry1.startVerseId,
           endVerseId: logEntry1.endVerseId,
@@ -275,7 +301,7 @@ describe('log-entries.test.js', () => {
           .send(logEntry1);
 
         const response = await requestApi
-          .put(`/api/log-entries/${createResponse.body.id}`)
+          .put(`/api/log-entries/${createResponse.body.data.id}`)
           .send(logEntry2);
         expect(response.status).toBe(401);
       }
@@ -292,6 +318,8 @@ describe('log-entries.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(logEntry2);
         expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -308,10 +336,12 @@ describe('log-entries.test.js', () => {
           .send(logEntry1);
 
         const response = await requestApi
-          .put(`/api/log-entries/${createResponse.body.id}`)
+          .put(`/api/log-entries/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(invalidLogEntry2);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -328,12 +358,14 @@ describe('log-entries.test.js', () => {
           .send(logEntry1);
 
         const response = await requestApi
-          .put(`/api/log-entries/${createResponse.body.id}`)
+          .put(`/api/log-entries/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ date: logEntry2.date });
 
         expect(response.status).toBe(200);
-        expect(response.body.date).toBe(logEntry2.date);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.date).toBe(logEntry2.date);
       }
       finally {
         await deleteTestUser(testUser);
@@ -350,7 +382,7 @@ describe('log-entries.test.js', () => {
           .send(logEntry1);
 
         const response = await requestApi
-          .put(`/api/log-entries/${createResponse.body.id}`)
+          .put(`/api/log-entries/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({
             startVerseId: logEntry2.startVerseId,
@@ -358,8 +390,10 @@ describe('log-entries.test.js', () => {
           });
 
         expect(response.status).toBe(200);
-        expect(response.body.startVerseId).toBe(logEntry2.startVerseId);
-        expect(response.body.endVerseId).toBe(logEntry2.endVerseId);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.startVerseId).toBe(logEntry2.startVerseId);
+        expect(response.body.data.endVerseId).toBe(logEntry2.endVerseId);
       }
       finally {
         await deleteTestUser(testUser);
@@ -374,6 +408,8 @@ describe('log-entries.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(logEntry2);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -392,7 +428,7 @@ describe('log-entries.test.js', () => {
           .send(logEntry1);
 
         const response = await requestApi
-          .delete(`/api/log-entries/${createResponse.body.id}`);
+          .delete(`/api/log-entries/${createResponse.body.data.id}`);
         expect(response.status).toBe(401);
       }
       finally {
@@ -407,6 +443,8 @@ describe('log-entries.test.js', () => {
           .delete(`/api/log-entries/${missingObjectId}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -423,9 +461,12 @@ describe('log-entries.test.js', () => {
           .send(logEntry1);
 
         const response = await requestApi
-          .delete(`/api/log-entries/${createResponse.body.id}`)
+          .delete(`/api/log-entries/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data).toBe(1);
       }
       finally {
         await deleteTestUser(testUser);
@@ -443,14 +484,16 @@ describe('log-entries.test.js', () => {
 
         // First delete
         await requestApi
-          .delete(`/api/log-entries/${createResponse.body.id}`)
+          .delete(`/api/log-entries/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
 
         // Second delete
         const response = await requestApi
-          .delete(`/api/log-entries/${createResponse.body.id}`)
+          .delete(`/api/log-entries/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -464,6 +507,8 @@ describe('log-entries.test.js', () => {
           .delete('/api/log-entries/invalid-id')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);

--- a/api/test/passage-note-tags.test.ts
+++ b/api/test/passage-note-tags.test.ts
@@ -37,7 +37,9 @@ describe('passage-note-tags.test.js', () => {
           .get('/api/passage-note-tags')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(Array.isArray(response.body)).toBe(true);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(Array.isArray(response.body.data)).toBe(true);
       }
       finally {
         await deleteTestUser(testUser);
@@ -57,11 +59,13 @@ describe('passage-note-tags.test.js', () => {
           .get('/api/passage-note-tags')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body[0]).toHaveProperty('id');
-        expect(response.body[0]).toHaveProperty('label');
-        expect(response.body[0]).toHaveProperty('color');
-        expect(response.body[0]).toHaveProperty('description');
-        expect(response.body[0]).toHaveProperty('noteCount');
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data[0]).toHaveProperty('id');
+        expect(response.body.data[0]).toHaveProperty('label');
+        expect(response.body.data[0]).toHaveProperty('color');
+        expect(response.body.data[0]).toHaveProperty('description');
+        expect(response.body.data[0]).toHaveProperty('noteCount');
       }
       finally {
         await deleteTestUser(testUser);
@@ -83,6 +87,8 @@ describe('passage-note-tags.test.js', () => {
           .get('/api/passage-note-tags/invalid-id')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -96,6 +102,8 @@ describe('passage-note-tags.test.js', () => {
           .get(`/api/passage-note-tags/${missingObjectId}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -112,14 +120,16 @@ describe('passage-note-tags.test.js', () => {
           .send(tag1);
 
         const response = await requestApi
-          .get(`/api/passage-note-tags/${createResponse.body.id}`)
+          .get(`/api/passage-note-tags/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.id).toBe(createResponse.body.id);
-        expect(response.body.label).toBe(tag1.label);
-        expect(response.body.color).toBe(tag1.color);
-        expect(response.body.description).toBe(tag1.description);
-        expect(response.body.noteCount).toBe(0);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.id).toBe(createResponse.body.data.id);
+        expect(response.body.data.label).toBe(tag1.label);
+        expect(response.body.data.color).toBe(tag1.color);
+        expect(response.body.data.description).toBe(tag1.description);
+        expect(response.body.data.noteCount).toBe(0);
       }
       finally {
         await deleteTestUser(testUser);
@@ -143,6 +153,8 @@ describe('passage-note-tags.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({});
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -157,6 +169,8 @@ describe('passage-note-tags.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(invalidTag);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -171,10 +185,12 @@ describe('passage-note-tags.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(tag1);
         expect(response.status).toBe(200);
-        expect(response.body.label).toBe(tag1.label);
-        expect(response.body.color).toBe(tag1.color);
-        expect(response.body.description).toBe(tag1.description);
-        expect(response.body.noteCount).toBe(0);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.label).toBe(tag1.label);
+        expect(response.body.data.color).toBe(tag1.color);
+        expect(response.body.data.description).toBe(tag1.description);
+        expect(response.body.data.noteCount).toBe(0);
       }
       finally {
         await deleteTestUser(testUser);
@@ -189,10 +205,12 @@ describe('passage-note-tags.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(tag2);
         expect(response.status).toBe(200);
-        expect(response.body.label).toBe(tag2.label);
-        expect(response.body.color).toBe(tag2.color);
-        expect(response.body.description).toBe(tag2.description);
-        expect(response.body.noteCount).toBe(0);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.label).toBe(tag2.label);
+        expect(response.body.data.color).toBe(tag2.color);
+        expect(response.body.data.description).toBe(tag2.description);
+        expect(response.body.data.noteCount).toBe(0);
       }
       finally {
         await deleteTestUser(testUser);
@@ -209,7 +227,9 @@ describe('passage-note-tags.test.js', () => {
           .set('Authorization', `Bearer ${testUser1.token}`)
           .send(tag1);
         expect(response1.status).toBe(200);
-        expect(response1.body.label).toBe(tag1.label);
+        expect(response1.body).toHaveProperty('data');
+        expect(response1.body).not.toHaveProperty('error');
+        expect(response1.body.data.label).toBe(tag1.label);
 
         // Create tag with same label for second user
         const response2 = await requestApi
@@ -217,20 +237,22 @@ describe('passage-note-tags.test.js', () => {
           .set('Authorization', `Bearer ${testUser2.token}`)
           .send(tag1);
         expect(response2.status).toBe(200);
-        expect(response2.body.label).toBe(tag1.label);
+        expect(response2.body).toHaveProperty('data');
+        expect(response2.body).not.toHaveProperty('error');
+        expect(response2.body.data.label).toBe(tag1.label);
 
         // Verify both tags exist and have the same label
         const tags1 = await requestApi
           .get('/api/passage-note-tags')
           .set('Authorization', `Bearer ${testUser1.token}`);
-        expect(tags1.body.length).toBe(1);
-        expect(tags1.body[0].label).toBe(tag1.label);
+        expect(tags1.body.data.length).toBe(1);
+        expect(tags1.body.data[0].label).toBe(tag1.label);
 
         const tags2 = await requestApi
           .get('/api/passage-note-tags')
           .set('Authorization', `Bearer ${testUser2.token}`);
-        expect(tags2.body.length).toBe(1);
-        expect(tags2.body[0].label).toBe(tag1.label);
+        expect(tags2.body.data.length).toBe(1);
+        expect(tags2.body.data[0].label).toBe(tag1.label);
       }
       finally {
         await deleteTestUser(testUser1);
@@ -247,7 +269,9 @@ describe('passage-note-tags.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(tag1);
         expect(response1.status).toBe(200);
-        expect(response1.body.label).toBe(tag1.label);
+        expect(response1.body).toHaveProperty('data');
+        expect(response1.body).not.toHaveProperty('error');
+        expect(response1.body.data.label).toBe(tag1.label);
 
         // Try to create second tag with same label
         const response2 = await requestApi
@@ -255,14 +279,16 @@ describe('passage-note-tags.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(tag1);
         expect(response2.status).toBe(422);
-        expect(response2.body.errors.label).toBeDefined();
+        expect(response2.body).toHaveProperty('error');
+        expect(response2.body).not.toHaveProperty('data');
+        expect(response2.body.error.error).toBeDefined();
 
         // Verify only one tag exists
         const tags = await requestApi
           .get('/api/passage-note-tags')
           .set('Authorization', `Bearer ${testUser.token}`);
-        expect(tags.body.length).toBe(1);
-        expect(tags.body[0].label).toBe(tag1.label);
+        expect(tags.body.data.length).toBe(1);
+        expect(tags.body.data[0].label).toBe(tag1.label);
       }
       finally {
         await deleteTestUser(testUser);
@@ -281,7 +307,7 @@ describe('passage-note-tags.test.js', () => {
           .send(tag1);
 
         const response = await requestApi
-          .put(`/api/passage-note-tags/${createResponse.body.id}`)
+          .put(`/api/passage-note-tags/${createResponse.body.data.id}`)
           .send(tag2);
         expect(response.status).toBe(401);
       }
@@ -298,6 +324,8 @@ describe('passage-note-tags.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(tag1);
         expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -312,6 +340,8 @@ describe('passage-note-tags.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(tag1);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -328,13 +358,15 @@ describe('passage-note-tags.test.js', () => {
           .send(tag1);
 
         const response = await requestApi
-          .put(`/api/passage-note-tags/${createResponse.body.id}`)
+          .put(`/api/passage-note-tags/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ label: 'Updated Label' });
         expect(response.status).toBe(200);
-        expect(response.body.label).toBe('Updated Label');
-        expect(response.body.color).toBe(tag1.color);
-        expect(response.body.description).toBe(tag1.description);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.label).toBe('Updated Label');
+        expect(response.body.data.color).toBe(tag1.color);
+        expect(response.body.data.description).toBe(tag1.description);
       }
       finally {
         await deleteTestUser(testUser);
@@ -351,13 +383,15 @@ describe('passage-note-tags.test.js', () => {
           .send(tag1);
 
         const response = await requestApi
-          .put(`/api/passage-note-tags/${createResponse.body.id}`)
+          .put(`/api/passage-note-tags/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ color: '#00FF00' });
         expect(response.status).toBe(200);
-        expect(response.body.label).toBe(tag1.label);
-        expect(response.body.color).toBe('#00FF00');
-        expect(response.body.description).toBe(tag1.description);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.label).toBe(tag1.label);
+        expect(response.body.data.color).toBe('#00FF00');
+        expect(response.body.data.description).toBe(tag1.description);
       }
       finally {
         await deleteTestUser(testUser);
@@ -374,13 +408,15 @@ describe('passage-note-tags.test.js', () => {
           .send(tag1);
 
         const response = await requestApi
-          .put(`/api/passage-note-tags/${createResponse.body.id}`)
+          .put(`/api/passage-note-tags/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ description: 'Updated description' });
         expect(response.status).toBe(200);
-        expect(response.body.label).toBe(tag1.label);
-        expect(response.body.color).toBe(tag1.color);
-        expect(response.body.description).toBe('Updated description');
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.label).toBe(tag1.label);
+        expect(response.body.data.color).toBe(tag1.color);
+        expect(response.body.data.description).toBe('Updated description');
       }
       finally {
         await deleteTestUser(testUser);
@@ -399,7 +435,7 @@ describe('passage-note-tags.test.js', () => {
           .send(tag1);
 
         const response = await requestApi
-          .delete(`/api/passage-note-tags/${createResponse.body.id}`);
+          .delete(`/api/passage-note-tags/${createResponse.body.data.id}`);
         expect(response.status).toBe(401);
       }
       finally {
@@ -414,6 +450,8 @@ describe('passage-note-tags.test.js', () => {
           .delete(`/api/passage-note-tags/${missingObjectId}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -430,10 +468,12 @@ describe('passage-note-tags.test.js', () => {
           .send(tag1);
 
         const response = await requestApi
-          .delete(`/api/passage-note-tags/${createResponse.body.id}`)
+          .delete(`/api/passage-note-tags/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body).toBe(1);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data).toBe(1);
       }
       finally {
         await deleteTestUser(testUser);
@@ -451,14 +491,16 @@ describe('passage-note-tags.test.js', () => {
 
         // First delete
         await requestApi
-          .delete(`/api/passage-note-tags/${createResponse.body.id}`)
+          .delete(`/api/passage-note-tags/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
 
         // Second delete
         const response = await requestApi
-          .delete(`/api/passage-note-tags/${createResponse.body.id}`)
+          .delete(`/api/passage-note-tags/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -472,6 +514,8 @@ describe('passage-note-tags.test.js', () => {
           .delete('/api/passage-note-tags/invalid-id')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);

--- a/api/test/passage-note-tags.test.ts
+++ b/api/test/passage-note-tags.test.ts
@@ -281,7 +281,9 @@ describe('passage-note-tags.test.js', () => {
         expect(response2.status).toBe(422);
         expect(response2.body).toHaveProperty('error');
         expect(response2.body).not.toHaveProperty('data');
-        expect(response2.body.error.error).toBeDefined();
+        expect(response2.body.error.code).toBe('validation_error');
+        expect(response2.body.error.errors).toBeDefined();
+        expect(Array.isArray(response2.body.error.errors)).toBe(true);
 
         // Verify only one tag exists
         const tags = await requestApi

--- a/api/test/passage-note-tags.test.ts
+++ b/api/test/passage-note-tags.test.ts
@@ -278,7 +278,7 @@ describe('passage-note-tags.test.js', () => {
           .post('/api/passage-note-tags')
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(tag1);
-        expect(response2.status).toBe(422);
+        expect(response2.status).toBe(400);
         expect(response2.body).toHaveProperty('error');
         expect(response2.body).not.toHaveProperty('data');
         expect(response2.body.error.code).toBe('validation_error');

--- a/api/test/passage-notes.test.ts
+++ b/api/test/passage-notes.test.ts
@@ -15,7 +15,7 @@ async function createPassageNoteTags(testUser, tags) {
         .send(tag),
     ),
   );
-  return tagResponses.map(response => response.body);
+  return tagResponses.map(response => response.body.data);
 }
 
 // Test data with tag IDs (to be populated during test setup)
@@ -37,22 +37,10 @@ const passageNote3 = {
   tags: [], // Will be populated with tag IDs during test setup
 };
 
-const invalidPassageNote1 = {
-  passages: [{ startVerseId: 100000000, endVerseId: 100000001 }], // Invalid verse IDs
-  content: 'x'.repeat(3001),
-  tags: ['nonexistent-tag'],
-};
-
-const invalidPassageNote2 = {
+const invalidPassageNote = {
   passages: [{ startVerseId: 101001005, endVerseId: 101001001 }], // Start verse after end verse
   content: 'Test note 7',
   tags: ['Theology'],
-};
-
-const invalidPassageNote3 = {
-  passages: [{ startVerseId: 101001001, endVerseId: 143001005 }], // Different books
-  content: 'Test note 8',
-  tags: ['Application'],
 };
 
 const missingObjectId = '666666666666666666666666';
@@ -72,11 +60,14 @@ describe('passage-notes.test.js', () => {
           .get('/api/passage-notes')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body).toHaveProperty('offset');
-        expect(response.body).toHaveProperty('limit');
-        expect(response.body).toHaveProperty('size');
-        expect(response.body).toHaveProperty('results');
-        expect(Array.isArray(response.body.results)).toBe(true);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).toHaveProperty('meta');
+        expect(response.body).not.toHaveProperty('error');
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.meta).toHaveProperty('pagination');
+        expect(response.body.meta.pagination).toHaveProperty('offset');
+        expect(response.body.meta.pagination).toHaveProperty('limit');
+        expect(response.body.meta.pagination).toHaveProperty('size');
       }
       finally {
         await deleteTestUser(testUser);
@@ -90,6 +81,7 @@ describe('passage-notes.test.js', () => {
           .get('/api/passage-notes?limit=invalid&offset=invalid&sortOn=invalid&sortDirection=invalid')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(400);
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -103,6 +95,7 @@ describe('passage-notes.test.js', () => {
           .get('/api/passage-notes?filterTags=invalid&filterTagMatching=invalid&filterPassageStartVerseId=invalid&filterPassageEndVerseId=invalid&filterPassageMatching=invalid')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(400);
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -130,17 +123,24 @@ describe('passage-notes.test.js', () => {
           .get('/api/passage-notes')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body).toHaveProperty('results');
-        expect(response.body).toHaveProperty('offset');
-        expect(response.body).toHaveProperty('limit');
-        expect(response.body).toHaveProperty('size');
-        expect(Array.isArray(response.body.results)).toBe(true);
-        expect(response.body.results[0]).toHaveProperty('id');
-        expect(response.body.results[0]).toHaveProperty('passages');
-        expect(response.body.results[0]).toHaveProperty('content');
-        expect(response.body.results[0]).toHaveProperty('tags');
-        expect(response.body.results[0]).toHaveProperty('createdAt');
-        expect(response.body.results[0]).toHaveProperty('updatedAt');
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).toHaveProperty('meta');
+        expect(response.body).not.toHaveProperty('error');
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.meta).toHaveProperty('pagination');
+        expect(response.body.meta.pagination).toHaveProperty('offset');
+        expect(response.body.meta.pagination).toHaveProperty('limit');
+        expect(response.body.meta.pagination).toHaveProperty('size');
+        expect(response.body.data.length).toBeGreaterThan(0);
+        expect(response.body.data[0]).toHaveProperty('id');
+        expect(response.body.data[0]).toHaveProperty('passages');
+        expect(response.body.data[0]).toHaveProperty('content');
+        expect(response.body.data[0]).toHaveProperty('tags');
+        expect(response.body.data[0]).toHaveProperty('createdAt');
+        expect(response.body.data[0]).toHaveProperty('updatedAt');
+        expect(response.body.meta.pagination.offset).toBe(0);
+        expect(response.body.meta.pagination.limit).toBe(10);
+        expect(response.body.meta.pagination.size).toBe(1);
       }
       finally {
         await deleteTestUser(testUser);
@@ -168,8 +168,19 @@ describe('passage-notes.test.js', () => {
           .get(`/api/passage-notes?filterTags=${tags[0].id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.results.length).toBe(1);
-        expect(response.body.results[0].id).toBe(createResponse.body.id);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).toHaveProperty('meta');
+        expect(response.body).not.toHaveProperty('error');
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.data.length).toBe(1);
+        expect(response.body.data[0].id).toBe(createResponse.body.data.id);
+        expect(response.body.meta).toHaveProperty('pagination');
+        expect(response.body.meta.pagination).toHaveProperty('offset');
+        expect(response.body.meta.pagination).toHaveProperty('limit');
+        expect(response.body.meta.pagination).toHaveProperty('size');
+        expect(response.body.meta.pagination.offset).toBe(0);
+        expect(response.body.meta.pagination.limit).toBe(10);
+        expect(response.body.meta.pagination.size).toBe(1);
       }
       finally {
         await deleteTestUser(testUser);
@@ -192,8 +203,19 @@ describe('passage-notes.test.js', () => {
           .get(`/api/passage-notes?filterPassageStartVerseId=${passageNote1.passages[0]!.startVerseId}&filterPassageEndVerseId=${passageNote1.passages[0]!.endVerseId}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.results.length).toBe(1);
-        expect(response.body.results[0].id).toBe(createResponse.body.id);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).toHaveProperty('meta');
+        expect(response.body).not.toHaveProperty('error');
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.data.length).toBe(1);
+        expect(response.body.data[0].id).toBe(createResponse.body.data.id);
+        expect(response.body.meta).toHaveProperty('pagination');
+        expect(response.body.meta.pagination).toHaveProperty('offset');
+        expect(response.body.meta.pagination).toHaveProperty('limit');
+        expect(response.body.meta.pagination).toHaveProperty('size');
+        expect(response.body.meta.pagination.offset).toBe(0);
+        expect(response.body.meta.pagination.limit).toBe(10);
+        expect(response.body.meta.pagination.size).toBe(1);
       }
       finally {
         await deleteTestUser(testUser);
@@ -216,8 +238,19 @@ describe('passage-notes.test.js', () => {
           .get('/api/passage-notes?searchText=Test note 1')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.results.length).toBe(1);
-        expect(response.body.results[0].id).toBe(createResponse.body.id);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).toHaveProperty('meta');
+        expect(response.body).not.toHaveProperty('error');
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.data.length).toBe(1);
+        expect(response.body.data[0].id).toBe(createResponse.body.data.id);
+        expect(response.body.meta).toHaveProperty('pagination');
+        expect(response.body.meta.pagination).toHaveProperty('offset');
+        expect(response.body.meta.pagination).toHaveProperty('limit');
+        expect(response.body.meta.pagination).toHaveProperty('size');
+        expect(response.body.meta.pagination.offset).toBe(0);
+        expect(response.body.meta.pagination.limit).toBe(10);
+        expect(response.body.meta.pagination.size).toBe(1);
       }
       finally {
         await deleteTestUser(testUser);
@@ -245,8 +278,19 @@ describe('passage-notes.test.js', () => {
           .get('/api/passage-notes?sortOn=createdAt&sortDirection=descending')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body.results.length).toBe(2);
-        expect(new Date(response.body.results[0].createdAt) > new Date(response.body.results[1].createdAt)).toBe(true);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).toHaveProperty('meta');
+        expect(response.body).not.toHaveProperty('error');
+        expect(Array.isArray(response.body.data)).toBe(true);
+        expect(response.body.data.length).toBe(2);
+        expect(new Date(response.body.data[0].createdAt) > new Date(response.body.data[1].createdAt)).toBe(true);
+        expect(response.body.meta).toHaveProperty('pagination');
+        expect(response.body.meta.pagination).toHaveProperty('offset');
+        expect(response.body.meta.pagination).toHaveProperty('limit');
+        expect(response.body.meta.pagination).toHaveProperty('size');
+        expect(response.body.meta.pagination.offset).toBe(0);
+        expect(response.body.meta.pagination.limit).toBe(10);
+        expect(response.body.meta.pagination.size).toBe(2);
       }
       finally {
         await deleteTestUser(testUser);
@@ -271,9 +315,10 @@ describe('passage-notes.test.js', () => {
             .set('Authorization', `Bearer ${testUser.token}`)
             .send({});
           expect(response.status).toBe(400);
-          expect(response.body.errors).toEqual({
+          expect(response.body).toHaveProperty('error');
+          expect(response.body).not.toHaveProperty('data');
+          expect(response.body.error).toEqual({
             error: { message: 'Invalid passage note' },
-            message: 'Invalid passage note',
           });
         }
         finally {
@@ -295,9 +340,10 @@ describe('passage-notes.test.js', () => {
               }],
             });
           expect(response.status).toBe(400);
-          expect(response.body.errors).toEqual({
+          expect(response.body).toHaveProperty('error');
+          expect(response.body).not.toHaveProperty('data');
+          expect(response.body.error).toEqual({
             error: { message: 'Invalid passage note' },
-            message: 'Invalid passage note',
           });
         }
         finally {
@@ -319,9 +365,10 @@ describe('passage-notes.test.js', () => {
               }],
             });
           expect(response.status).toBe(400);
-          expect(response.body.errors).toEqual({
+          expect(response.body).toHaveProperty('error');
+          expect(response.body).not.toHaveProperty('data');
+          expect(response.body.error).toEqual({
             error: { message: 'Invalid passage note' },
-            message: 'Invalid passage note',
           });
         }
         finally {
@@ -336,8 +383,13 @@ describe('passage-notes.test.js', () => {
         const response = await requestApi
           .post('/api/passage-notes')
           .set('Authorization', `Bearer ${testUser.token}`)
-          .send(invalidPassageNote2);
+          .send(invalidPassageNote);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
+        expect(response.body.error).toEqual({
+          error: { message: 'Invalid passage note' },
+        });
       }
       finally {
         await deleteTestUser(testUser);
@@ -359,9 +411,8 @@ describe('passage-notes.test.js', () => {
 
       // Assert
       expect(response.statusCode).toBe(400);
-      expect(response.body.errors).toEqual({
+      expect(response.body.error).toEqual({
         error: { message: 'Invalid passage note' },
-        message: 'Invalid passage note',
       });
 
       // Cleanup
@@ -387,9 +438,8 @@ describe('passage-notes.test.js', () => {
 
       // Assert
       expect(response.statusCode).toBe(400);
-      expect(response.body.errors).toEqual({
+      expect(response.body.error).toEqual({
         error: { message: 'Invalid passage note' },
-        message: 'Invalid passage note',
       });
 
       // Cleanup
@@ -404,6 +454,8 @@ describe('passage-notes.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ passages: [], content: '' });
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -418,9 +470,11 @@ describe('passage-notes.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ passages: passageNote1.passages });
         expect(response.status).toBe(200);
-        expect(response.body.passages.length).toEqual(passageNote1.passages.length);
-        expect(response.body.passages[0].startVerseId).toEqual(passageNote1.passages[0]!.startVerseId);
-        expect(response.body.passages[0].endVerseId).toEqual(passageNote1.passages[0]!.endVerseId);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.passages.length).toEqual(passageNote1.passages.length);
+        expect(response.body.data.passages[0].startVerseId).toEqual(passageNote1.passages[0]!.startVerseId);
+        expect(response.body.data.passages[0].endVerseId).toEqual(passageNote1.passages[0]!.endVerseId);
       }
       finally {
         await deleteTestUser(testUser);
@@ -435,7 +489,9 @@ describe('passage-notes.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ content: passageNote2.content });
         expect(response.status).toBe(200);
-        expect(response.body.content).toBe(passageNote2.content);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.content).toBe(passageNote2.content);
       }
       finally {
         await deleteTestUser(testUser);
@@ -453,10 +509,12 @@ describe('passage-notes.test.js', () => {
             content: passageNote3.content,
           });
         expect(response.status).toBe(200);
-        expect(response.body.passages.length).toEqual(passageNote3.passages.length);
-        expect(response.body.passages[0].startVerseId).toEqual(passageNote3.passages[0]!.startVerseId);
-        expect(response.body.passages[0].endVerseId).toEqual(passageNote3.passages[0]!.endVerseId);
-        expect(response.body.content).toBe(passageNote3.content);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.passages.length).toEqual(passageNote3.passages.length);
+        expect(response.body.data.passages[0].startVerseId).toEqual(passageNote3.passages[0]!.startVerseId);
+        expect(response.body.data.passages[0].endVerseId).toEqual(passageNote3.passages[0]!.endVerseId);
+        expect(response.body.data.content).toBe(passageNote3.content);
       }
       finally {
         await deleteTestUser(testUser);
@@ -479,7 +537,9 @@ describe('passage-notes.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(noteWithTag);
         expect(response.status).toBe(200);
-        expect(response.body.tags).toEqual([tags[0].id]);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.tags).toEqual([tags[0].id]);
       }
       finally {
         await deleteTestUser(testUser);
@@ -501,7 +561,7 @@ describe('passage-notes.test.js', () => {
           .send(passageNote1);
 
         const response = await requestApi
-          .put(`/api/passage-notes/${createResponse.body.id}`)
+          .put(`/api/passage-notes/${createResponse.body.data.id}`)
           .send(passageNote2);
         expect(response.status).toBe(401);
       }
@@ -518,6 +578,8 @@ describe('passage-notes.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(passageNote1);
         expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -537,13 +599,15 @@ describe('passage-notes.test.js', () => {
           .send(passageNote1);
 
         const response = await requestApi
-          .put(`/api/passage-notes/${createResponse.body.id}`)
+          .put(`/api/passage-notes/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ passages: passageNote2.passages });
         expect(response.status).toBe(200);
-        expect(response.body.passages.length).toEqual(passageNote2.passages.length);
-        expect(response.body.passages[0].startVerseId).toEqual(passageNote2.passages[0]!.startVerseId);
-        expect(response.body.passages[0].endVerseId).toEqual(passageNote2.passages[0]!.endVerseId);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.passages.length).toEqual(passageNote2.passages.length);
+        expect(response.body.data.passages[0].startVerseId).toEqual(passageNote2.passages[0]!.startVerseId);
+        expect(response.body.data.passages[0].endVerseId).toEqual(passageNote2.passages[0]!.endVerseId);
       }
       finally {
         await deleteTestUser(testUser);
@@ -563,11 +627,13 @@ describe('passage-notes.test.js', () => {
           .send(passageNote1);
 
         const response = await requestApi
-          .put(`/api/passage-notes/${createResponse.body.id}`)
+          .put(`/api/passage-notes/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ content: passageNote2.content });
         expect(response.status).toBe(200);
-        expect(response.body.content).toBe(passageNote2.content);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.content).toBe(passageNote2.content);
       }
       finally {
         await deleteTestUser(testUser);
@@ -587,11 +653,13 @@ describe('passage-notes.test.js', () => {
           .send(passageNote1);
 
         const response = await requestApi
-          .put(`/api/passage-notes/${createResponse.body.id}`)
+          .put(`/api/passage-notes/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ tags: [tags[0].id] });
         expect(response.status).toBe(200);
-        expect(response.body.tags).toEqual([tags[0].id]);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data.tags).toEqual([tags[0].id]);
       }
       finally {
         await deleteTestUser(testUser);
@@ -606,6 +674,8 @@ describe('passage-notes.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send(passageNote1);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -627,7 +697,7 @@ describe('passage-notes.test.js', () => {
           .send(passageNote1);
 
         const response = await requestApi
-          .delete(`/api/passage-notes/${createResponse.body.id}`);
+          .delete(`/api/passage-notes/${createResponse.body.data.id}`);
         expect(response.status).toBe(401);
       }
       finally {
@@ -642,6 +712,8 @@ describe('passage-notes.test.js', () => {
           .delete(`/api/passage-notes/${missingObjectId}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -661,10 +733,12 @@ describe('passage-notes.test.js', () => {
           .send(passageNote1);
 
         const response = await requestApi
-          .delete(`/api/passage-notes/${createResponse.body.id}`)
+          .delete(`/api/passage-notes/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body).toBe(1);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data).toBe(1);
       }
       finally {
         await deleteTestUser(testUser);
@@ -685,14 +759,16 @@ describe('passage-notes.test.js', () => {
 
         // First delete
         await requestApi
-          .delete(`/api/passage-notes/${createResponse.body.id}`)
+          .delete(`/api/passage-notes/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
 
         // Second delete
         const response = await requestApi
-          .delete(`/api/passage-notes/${createResponse.body.id}`)
+          .delete(`/api/passage-notes/${createResponse.body.data.id}`)
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(404);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -706,6 +782,8 @@ describe('passage-notes.test.js', () => {
           .delete('/api/passage-notes/invalid-id')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);
@@ -832,6 +910,8 @@ describe('passage-notes.test.js', () => {
           .get('/api/passage-notes/invalid-id')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(400);
+        expect(response.body).toHaveProperty('error');
+        expect(response.body).not.toHaveProperty('data');
       }
       finally {
         await deleteTestUser(testUser);

--- a/api/test/passage-notes.test.ts
+++ b/api/test/passage-notes.test.ts
@@ -805,12 +805,14 @@ describe('passage-notes.test.js', () => {
           .get('/api/passage-notes/count/books')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(typeof response.body).toBe('object');
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(typeof response.body.data).toBe('object');
         // Check that all Bible books are present in the response
-        expect(response.body).toHaveProperty('1');
-        expect(response.body).toHaveProperty('66');
+        expect(response.body.data).toHaveProperty('1');
+        expect(response.body.data).toHaveProperty('66');
         // Check that all values are numbers
-        Object.values(response.body).forEach((value) => {
+        Object.values(response.body.data).forEach((value) => {
           expect(typeof value).toBe('number');
         });
       }
@@ -856,9 +858,11 @@ describe('passage-notes.test.js', () => {
           .get('/api/passage-notes/count/books')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body[1]).toBe(2); // 2 notes in Genesis
-        expect(response.body[2]).toBe(1); // 1 note in Exodus
-        expect(response.body[66]).toBe(0); // 0 notes in Revelation
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data[1]).toEqual(2); // 2 notes in Genesis
+        expect(response.body.data[2]).toEqual(1); // 1 note in Exodus
+        expect(response.body.data[66]).toEqual(0); // 0 notes in Revelation
       }
       finally {
         await deleteTestUser(testUser);
@@ -887,8 +891,10 @@ describe('passage-notes.test.js', () => {
           .get('/api/passage-notes/count/books')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body[1]).toBe(1); // Note counted in Genesis
-        expect(response.body[2]).toBe(1); // Note counted in Exodus
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data[1]).toEqual(1); // Note counted in Genesis
+        expect(response.body.data[2]).toEqual(1); // Note counted in Exodus
       }
       finally {
         await deleteTestUser(testUser);

--- a/api/test/passage-notes.test.ts
+++ b/api/test/passage-notes.test.ts
@@ -317,9 +317,7 @@ describe('passage-notes.test.js', () => {
           expect(response.status).toBe(400);
           expect(response.body).toHaveProperty('error');
           expect(response.body).not.toHaveProperty('data');
-          expect(response.body.error).toEqual({
-            error: { message: 'Invalid passage note' },
-          });
+          expect(response.body.error.code).toBe('validation_error');
         }
         finally {
           await deleteTestUser(testUser);
@@ -342,9 +340,7 @@ describe('passage-notes.test.js', () => {
           expect(response.status).toBe(400);
           expect(response.body).toHaveProperty('error');
           expect(response.body).not.toHaveProperty('data');
-          expect(response.body.error).toEqual({
-            error: { message: 'Invalid passage note' },
-          });
+          expect(response.body.error.code).toBe('validation_error');
         }
         finally {
           await deleteTestUser(testUser);
@@ -367,9 +363,7 @@ describe('passage-notes.test.js', () => {
           expect(response.status).toBe(400);
           expect(response.body).toHaveProperty('error');
           expect(response.body).not.toHaveProperty('data');
-          expect(response.body.error).toEqual({
-            error: { message: 'Invalid passage note' },
-          });
+          expect(response.body.error.code).toBe('validation_error');
         }
         finally {
           await deleteTestUser(testUser);
@@ -387,9 +381,7 @@ describe('passage-notes.test.js', () => {
         expect(response.status).toBe(400);
         expect(response.body).toHaveProperty('error');
         expect(response.body).not.toHaveProperty('data');
-        expect(response.body.error).toEqual({
-          error: { message: 'Invalid passage note' },
-        });
+        expect(response.body.error.code).toBe('validation_error');
       }
       finally {
         await deleteTestUser(testUser);
@@ -411,9 +403,7 @@ describe('passage-notes.test.js', () => {
 
       // Assert
       expect(response.statusCode).toBe(400);
-      expect(response.body.error).toEqual({
-        error: { message: 'Invalid passage note' },
-      });
+      expect(response.body.error.code).toBe('validation_error');
 
       // Cleanup
       await deleteTestUser(testUser);
@@ -438,9 +428,7 @@ describe('passage-notes.test.js', () => {
 
       // Assert
       expect(response.statusCode).toBe(400);
-      expect(response.body.error).toEqual({
-        error: { message: 'Invalid passage note' },
-      });
+      expect(response.body.error.code).toBe('validation_error');
 
       // Cleanup
       await deleteTestUser(testUser);

--- a/api/test/reminders.test.ts
+++ b/api/test/reminders.test.ts
@@ -20,11 +20,13 @@ describe('Reminders routes', () => {
 
     // Assert
     expect(res.statusCode).toBe(200);
-    expect(res.body).toHaveProperty('id');
-    expect(res.body).toHaveProperty('hour');
-    expect(res.body).toHaveProperty('minute');
-    expect(res.body).toHaveProperty('timezoneOffset');
-    expect(res.body).toHaveProperty('active');
+    expect(res.body).toHaveProperty('data');
+    expect(res.body).not.toHaveProperty('error');
+    expect(res.body.data).toHaveProperty('id');
+    expect(res.body.data).toHaveProperty('hour');
+    expect(res.body.data).toHaveProperty('minute');
+    expect(res.body.data).toHaveProperty('timezoneOffset');
+    expect(res.body.data).toHaveProperty('active');
   });
 
   test('PUT /api/reminders/daily-reminder (update single property)', async () => {
@@ -38,7 +40,9 @@ describe('Reminders routes', () => {
 
     // Assert
     expect(res.statusCode).toBe(200);
-    expect(res.body.hour).toBe(9);
+    expect(res.body).toHaveProperty('data');
+    expect(res.body).not.toHaveProperty('error');
+    expect(res.body.data.hour).toBe(9);
   });
 
   test('PUT /api/reminders/daily-reminder (update multiple properties)', async () => {
@@ -55,10 +59,12 @@ describe('Reminders routes', () => {
 
     // Assert
     expect(res.statusCode).toBe(200);
-    expect(res.body.hour).toBe(10);
-    expect(res.body.minute).toBe(30);
-    expect(res.body.timezoneOffset).toBe(-420);
-    expect(res.body.active).toBe(true);
+    expect(res.body).toHaveProperty('data');
+    expect(res.body).not.toHaveProperty('error');
+    expect(res.body.data.hour).toBe(10);
+    expect(res.body.data.minute).toBe(30);
+    expect(res.body.data.timezoneOffset).toBe(-420);
+    expect(res.body.data.active).toBe(true);
   });
 });
 

--- a/api/test/settings.test.ts
+++ b/api/test/settings.test.ts
@@ -17,15 +17,17 @@ describe('settings.test.js', () => {
           .get('/api/settings')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
-        expect(response.body).toHaveProperty('dailyVerseCountGoal');
-        expect(response.body).toHaveProperty('lookBackDate');
-        expect(response.body).toHaveProperty('preferredBibleVersion');
-        expect(response.body).toHaveProperty('startPage');
-        expect(response.body).toHaveProperty('locale');
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data).toHaveProperty('dailyVerseCountGoal');
+        expect(response.body.data).toHaveProperty('lookBackDate');
+        expect(response.body.data).toHaveProperty('preferredBibleVersion');
+        expect(response.body.data).toHaveProperty('startPage');
+        expect(response.body.data).toHaveProperty('locale');
 
         // verify lookBackDate is in correct format
-        expect(typeof response.body.lookBackDate).toBe('string');
-        expect(response.body.lookBackDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(typeof response.body.data.lookBackDate).toBe('string');
+        expect(response.body.data.lookBackDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
       }
       finally {
         await deleteTestUser(testUser);
@@ -48,7 +50,7 @@ describe('settings.test.js', () => {
         const getResponse = await requestApi
           .get('/api/settings')
           .set('Authorization', `Bearer ${testUser.token}`);
-        const originalGoal = getResponse.body.dailyVerseCountGoal;
+        const originalGoal = getResponse.body.data.dailyVerseCountGoal;
 
         // Update just the dailyVerseCountGoal
         const newGoal = originalGoal + 10;
@@ -57,12 +59,14 @@ describe('settings.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ settings: { dailyVerseCountGoal: newGoal } });
         expect(putResponse.status).toBe(200);
+        expect(putResponse.body).toHaveProperty('data');
+        expect(putResponse.body).not.toHaveProperty('error');
 
         // Verify the change
         const verifyResponse = await requestApi
           .get('/api/settings')
           .set('Authorization', `Bearer ${testUser.token}`);
-        expect(verifyResponse.body.dailyVerseCountGoal).toBe(newGoal);
+        expect(verifyResponse.body.data.dailyVerseCountGoal).toBe(newGoal);
       }
       finally {
         await deleteTestUser(testUser);
@@ -84,12 +88,14 @@ describe('settings.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ settings: newSettings });
         expect(putResponse.status).toBe(200);
+        expect(putResponse.body).toHaveProperty('data');
+        expect(putResponse.body).not.toHaveProperty('error');
 
         // Verify all changes
         const verifyResponse = await requestApi
           .get('/api/settings')
           .set('Authorization', `Bearer ${testUser.token}`);
-        expect(verifyResponse.body).toMatchObject(newSettings);
+        expect(verifyResponse.body.data).toMatchObject(newSettings);
       }
       finally {
         await deleteTestUser(testUser);
@@ -103,7 +109,7 @@ describe('settings.test.js', () => {
         const getResponse = await requestApi
           .get('/api/settings')
           .set('Authorization', `Bearer ${testUser.token}`);
-        const originalSettings = { ...getResponse.body };
+        const originalSettings = { ...getResponse.body.data };
 
         // Update with some undefined values
         const putResponse = await requestApi
@@ -111,43 +117,19 @@ describe('settings.test.js', () => {
           .set('Authorization', `Bearer ${testUser.token}`)
           .send({ settings: { dailyVerseCountGoal: 100, lookBackDate: undefined } });
         expect(putResponse.status).toBe(200);
+        expect(putResponse.body).toHaveProperty('data');
+        expect(putResponse.body).not.toHaveProperty('error');
 
         // Verify only the defined setting changed
         const verifyResponse = await requestApi
           .get('/api/settings')
           .set('Authorization', `Bearer ${testUser.token}`);
-        expect(verifyResponse.body.dailyVerseCountGoal).toBe(100);
-        expect(verifyResponse.body.lookBackDate).toBe(originalSettings.lookBackDate);
+        expect(verifyResponse.body.data.dailyVerseCountGoal).toBe(100);
+        expect(verifyResponse.body.data.lookBackDate).toBe(originalSettings.lookBackDate);
       }
       finally {
         await deleteTestUser(testUser);
       }
-    });
-  });
-
-  describe('PUT /api/settings/change-password', () => {
-    test('Incorrect password for password change', async () => {
-      // Arrange
-      const testUser = await createTestUser();
-
-      // Act
-      const response = await requestApi
-        .put('/api/settings/change-password')
-        .set('Authorization', `Bearer ${testUser.token}`)
-        .send({
-          currentPassword: 'wrongpassword',
-          newPassword: 'newpassword123',
-        });
-
-      // Assert
-      expect(response.statusCode).toBe(404);
-      expect(response.body.errors).toEqual({
-        error: { message: 'Not Found' },
-        message: 'Not Found',
-      });
-
-      // Cleanup
-      await deleteTestUser(testUser);
     });
   });
 
@@ -165,6 +147,9 @@ describe('settings.test.js', () => {
           .put('/api/settings/delete-account')
           .set('Authorization', `Bearer ${testUser.token}`);
         expect(response.status).toBe(200);
+        expect(response.body).toHaveProperty('data');
+        expect(response.body).not.toHaveProperty('error');
+        expect(response.body.data).toBe(1);
         // expect cookie to be cleared in header
         expect(response.headers['set-cookie']).toBeDefined();
         expect(response.headers['set-cookie']?.[0]).toContain(`${AUTH_COOKIE_NAME}=;`);

--- a/nuxt/components/BibleReport.vue
+++ b/nuxt/components/BibleReport.vue
@@ -104,7 +104,8 @@ export default {
     })
       .then(async (response) => {
         if (response.ok) {
-          this.bookNotesCounts = await response.json();
+          const responseData = await response.json();
+          this.bookNotesCounts = responseData.data;
           for (let i = 1, l = Bible.getBookCount(); i <= l; i++) {
             if (this.bookNotesCounts[i] > 0) {
               this.anyBooksHaveNotes = true;

--- a/nuxt/components/BibleReport.vue
+++ b/nuxt/components/BibleReport.vue
@@ -98,23 +98,20 @@ export default {
       return segments;
     },
   },
-  mounted() {
-    fetch('/api/passage-notes/count/books', {
-      credentials: 'include',
-    })
-      .then(async (response) => {
-        if (response.ok) {
-          const responseData = await response.json();
-          this.bookNotesCounts = responseData.data;
-          for (let i = 1, l = Bible.getBookCount(); i <= l; i++) {
-            if (this.bookNotesCounts[i] > 0) {
-              this.anyBooksHaveNotes = true;
-              break;
-            }
-          }
+  async mounted() {
+    try {
+      const { data: bookNotesCounts } = await this.$http.get('/api/passage-notes/count/books');
+      this.bookNotesCounts = bookNotesCounts;
+      for (let i = 1, l = Bible.getBookCount(); i <= l; i++) {
+        if (this.bookNotesCounts[i] > 0) {
+          this.anyBooksHaveNotes = true;
+          break;
         }
-      })
-      .catch();
+      }
+    }
+    catch {
+      // Leave bookNotesCounts as {} on error
+    }
   },
   methods: {
     bookReport(bookIndex) {

--- a/nuxt/components/LogEntry.vue
+++ b/nuxt/components/LogEntry.vue
@@ -156,7 +156,7 @@ export default {
     "new": "novos | novos"
   },
   "uk": {
-    "verse": "верс | верси",
+    "verse": "верс | віршів",
     "all": "всі | всі",
     "new": "новий | нові"
   }

--- a/nuxt/components/forms/FeedbackForm.vue
+++ b/nuxt/components/forms/FeedbackForm.vue
@@ -55,6 +55,8 @@
 </template>
 
 <script>
+import mapFormErrors from '~/helpers/map-form-errors';
+
 export default {
   name: 'FeedbackForm',
   data() {
@@ -84,9 +86,9 @@ export default {
           }),
         });
         if (!response.ok) {
-          const errorData = await response.json();
+          const responseData = await response.json();
           const error = new Error('Failed to submit feedback');
-          error.response = { data: errorData };
+          error.response = { data: responseData };
           throw error;
         }
 
@@ -103,7 +105,13 @@ export default {
       }
       catch (err) {
         const unknownError = { _form: this.$t('messaging.unknown_error') };
-        this.errors = err.response?.data?.errors || unknownError;
+        const errorData = err.response?.data;
+        if (errorData?.error) {
+          this.errors = mapFormErrors(errorData.error) || unknownError;
+        }
+        else {
+          this.errors = unknownError;
+        }
       }
     },
   },

--- a/nuxt/components/forms/PassageNoteTagEditorForm.vue
+++ b/nuxt/components/forms/PassageNoteTagEditorForm.vue
@@ -2,7 +2,7 @@
   <form @submit.prevent="handleSubmit">
     <div v-if="errors._form" class="help is-danger">
       <div class="help is-danger">
-        {{ errors._form }}
+        {{ $terr(errors._form) }}
       </div>
     </div>
     <div class="field">

--- a/nuxt/helpers/api-error.js
+++ b/nuxt/helpers/api-error.js
@@ -26,5 +26,7 @@ export class ApiError extends Error {
 }
 
 export class UnknownApiError extends ApiError {
-  code = 'unknown_error';
+  constructor() {
+    super({ code: 'unknown_error', errors: [] });
+  }
 }

--- a/nuxt/helpers/api-error.js
+++ b/nuxt/helpers/api-error.js
@@ -1,0 +1,30 @@
+export class ApiError extends Error {
+  /**
+   * Top-level error code.
+   * @type {string}
+   */
+  code;
+  /**
+   * Array of field-level errors.
+   * @type {ApiErrorDetail[]}
+   */
+  errors;
+
+  /**
+   * Creates a new ApiError.
+   * @param {Object} payload - The payload to create the ApiError from.
+   * @param {string} payload.code - The code of the error.
+   * @param {ApiErrorDetail[]} payload.errors - The errors of the error.
+   */
+  constructor(payload) {
+    super(payload.code);
+
+    this.name = 'ApiError';
+    this.code = payload.code;
+    this.errors = payload.errors ?? [];
+  }
+}
+
+export class UnknownApiError extends ApiError {
+  code = 'unknown_error';
+}

--- a/nuxt/helpers/map-form-errors.js
+++ b/nuxt/helpers/map-form-errors.js
@@ -19,7 +19,7 @@
 const mapFormErrors = (error) => {
   const formErrors = {};
   if (!error.errors?.length) {
-    formErrors._form = error.code;
+    formErrors._form = { code: error.code };
   }
   return error.errors?.reduce((acc, err) => {
     if (err.field) {

--- a/nuxt/helpers/map-form-errors.js
+++ b/nuxt/helpers/map-form-errors.js
@@ -1,0 +1,35 @@
+/**
+ * @typedef {Object} ApiErrorDetail
+ * @property {string|null} field - Field name for field-level errors. Set to `null` for top-level errors.
+ * @property {string} code - Machine-readable i18n-friendly code.
+ * @property {Record<string, any>} [properties] - Optional metadata for the error.
+ */
+
+/**
+ * @typedef {Object} ApiError
+ * @property {string} code - Top-level error code.
+ * @property {ApiErrorDetail[]} [errors] - Optional array of field errors.
+ */
+
+/**
+ * Converts a normalized API error structure to a map of form errors.
+ * @param {ApiError} error - The API error object.
+ * @returns {Record<string, ApiErrorDetail>} A map of field names to error details.
+ */
+const mapFormErrors = (error) => {
+  const formErrors = {};
+  if (!error.errors?.length) {
+    formErrors._form = error.code;
+  }
+  return error.errors?.reduce((acc, err) => {
+    if (err.field) {
+      acc[err.field] = err;
+    }
+    else {
+      acc._form = err;
+    }
+    return acc;
+  }, formErrors) ?? formErrors;
+};
+
+export default mapFormErrors;

--- a/nuxt/locales/locale.d.ts
+++ b/nuxt/locales/locale.d.ts
@@ -12,6 +12,8 @@ export type Translation = {
     max_length: string;
     review: string;
 
+    not_found: string;
+
     // Custom Errors
     invalid_login: string;
     verify_email: string;

--- a/nuxt/locales/locale.d.ts
+++ b/nuxt/locales/locale.d.ts
@@ -3,6 +3,8 @@ export type Translation = {
   my_bible_log: string;
   api_error: {
     // Request Input Validation Errors
+    unknown_error: string;
+    validation_error: string;
     required: string;
     is_invalid: string;
     unique: string;

--- a/nuxt/locales/locales.ts
+++ b/nuxt/locales/locales.ts
@@ -13,6 +13,8 @@ const locales: Locales = {
       max_length: 'Must be {maxlength} or fewer characters',
       review: 'Please review.',
 
+      not_found: 'Not found',
+
       invalid_login: 'Email or password is incorrect',
       verify_email: 'Please check {email} to verify your email first',
       new_email_required: 'New email cannot be the same as current email',
@@ -43,6 +45,8 @@ const locales: Locales = {
       min_length: 'Debe tener {minlength} o más caracteres',
       max_length: 'Debe tener {maxlength} o menos caracteres',
       review: 'Por favor revise.',
+
+      not_found: 'No encontrado',
 
       invalid_login: 'El correo electrónico o la contraseña son incorrectos',
       verify_email: 'Por favor revise {email} para verificar su correo electrónico primero',
@@ -75,6 +79,8 @@ const locales: Locales = {
       max_length: 'Muss {maxlength} oder weniger Zeichen haben',
       review: 'Bitte überprüfen Sie.',
 
+      not_found: 'Nicht gefunden',
+
       invalid_login: 'Email oder Passwort ist falsch',
       verify_email: 'Bitte überprüfen Sie {email} zuerst, um Ihre Email zu bestätigen',
       new_email_required: 'Die neue Email kann nicht die gleiche wie die aktuelle Email sein',
@@ -105,6 +111,8 @@ const locales: Locales = {
       min_length: 'Doit contenir {minlength} caractères ou plus',
       max_length: 'Doit contenir {maxlength} caractères ou moins',
       review: 'Veuillez revoir.',
+
+      not_found: 'Non trouvé',
 
       invalid_login: 'Email ou mot de passe incorrect',
       verify_email: 'Veuillez vérifier {email} pour vérifier votre adresse email d\'abord',
@@ -137,6 +145,8 @@ const locales: Locales = {
       max_length: 'Deve ter {maxlength} ou menos caracteres',
       review: 'Por favor, revise.',
 
+      not_found: 'Não encontrado',
+
       invalid_login: 'Email ou senha incorretos',
       verify_email: 'Por favor, verifique {email} para confirmar seu email primeiro',
       new_email_required: 'O novo email não pode ser o mesmo que o email atual',
@@ -167,6 +177,8 @@ const locales: Locales = {
       min_length: 'Має бути {minlength} або більше символів',
       max_length: 'Має бути {maxlength} або менше символів',
       review: 'Будь ласка, перегляньте.',
+
+      not_found: 'Не знайдено',
 
       invalid_login: 'Електронна пошта або пароль невірні',
       verify_email: 'Будь ласка, перевірте {email}, щоб спочатку підтвердити свою електронну пошту',

--- a/nuxt/locales/locales.ts
+++ b/nuxt/locales/locales.ts
@@ -4,6 +4,8 @@ const locales: Locales = {
   en: {
     my_bible_log: 'My Bible Log',
     api_error: {
+      unknown_error: 'An unknown error occurred',
+      validation_error: 'There was an error with your request',
       required: 'A {field} is required',
       is_invalid: 'Please enter a valid {field}',
       unique: 'This {field} is already in use',
@@ -33,6 +35,8 @@ const locales: Locales = {
   es: {
     my_bible_log: 'My Bible Log',
     api_error: {
+      unknown_error: 'Ocurrió un error desconocido',
+      validation_error: 'Hubo un error con su solicitud',
       required: 'Se requiere un {field}',
       is_invalid: 'Por favor ingrese un {field} válido',
       unique: 'Este {field} ya está en uso',
@@ -62,6 +66,8 @@ const locales: Locales = {
   de: {
     my_bible_log: 'My Bible Log',
     api_error: {
+      unknown_error: 'Ein unbekannter Fehler ist aufgetreten',
+      validation_error: 'Es gab einen Fehler mit Ihrer Anfrage',
       required: 'Ein {field} ist erforderlich',
       is_invalid: 'Bitte geben Sie ein gültiges {field} ein',
       unique: 'Dieses {field} ist bereits in Verwendung',
@@ -91,6 +97,8 @@ const locales: Locales = {
   fr: {
     my_bible_log: 'My Bible Log',
     api_error: {
+      unknown_error: 'Une erreur inconnue est survenue',
+      validation_error: 'Il y a eu une erreur avec votre requête',
       required: 'Un(e) {field} est requis(e)',
       is_invalid: 'Veuillez entrer un(e) {field} valide',
       unique: 'Ce(tte) {field} est déjà utilisé(e)',
@@ -120,6 +128,8 @@ const locales: Locales = {
   pt: {
     my_bible_log: 'My Bible Log',
     api_error: {
+      unknown_error: 'Ocorreu um erro desconhecido',
+      validation_error: 'Houve um erro com sua solicitação',
       required: 'Um(a) {field} é obrigatório',
       is_invalid: 'Por favor, insira um(a) {field} válido',
       unique: 'Este(a) {field} já está em uso',
@@ -149,6 +159,8 @@ const locales: Locales = {
   uk: {
     my_bible_log: 'My Bible Log',
     api_error: {
+      unknown_error: 'Виникла невідома помилка',
+      validation_error: 'Виникла помилка з вашим запитом',
       required: 'Поле {field} обов\'язкове',
       is_invalid: 'Будь ласка, введіть дійсну {field}',
       unique: 'Це {field} вже використовується',

--- a/nuxt/nuxt.config.ts
+++ b/nuxt/nuxt.config.ts
@@ -62,6 +62,7 @@ const config: NuxtConfig = {
     '~/plugins/gtag.client.js',
     '~/plugins/translate-api.js',
     '~/plugins/nuxt-client-init.client.js',
+    '~/plugins/http.js',
   ],
   /*
   ** Nuxt.js dev-modules

--- a/nuxt/pages/admin/engagement.vue
+++ b/nuxt/pages/admin/engagement.vue
@@ -65,14 +65,8 @@ export default {
   methods: {
     async loadData() {
       try {
-        const response = await fetch(`/api/admin/reports/user-engagement/past-week`, {
-          credentials: 'include',
-        });
-        if (!response.ok) {
-          throw new Error('Failed to load engagement data');
-        }
-        const responseData = await response.json();
-        this.engagementData = responseData.data;
+        const { data: engagementData } = await this.$http.get('/api/admin/reports/user-engagement/past-week');
+        this.engagementData = engagementData;
       }
       catch (err) {
         await this.$store.dispatch('dialog/alert', {

--- a/nuxt/pages/admin/engagement.vue
+++ b/nuxt/pages/admin/engagement.vue
@@ -71,7 +71,8 @@ export default {
         if (!response.ok) {
           throw new Error('Failed to load engagement data');
         }
-        this.engagementData = await response.json();
+        const responseData = await response.json();
+        this.engagementData = responseData.data;
       }
       catch (err) {
         await this.$store.dispatch('dialog/alert', {

--- a/nuxt/pages/admin/feedback.vue
+++ b/nuxt/pages/admin/feedback.vue
@@ -77,7 +77,8 @@ export default {
       if (!response.ok) {
         throw new Error('Failed to load feedbacks');
       }
-      this.feedbacks = await response.json();
+      const responseData = await response.json();
+      this.feedbacks = responseData.data;
     },
     feedbackKindClass(kind) {
       return {

--- a/nuxt/pages/admin/feedback.vue
+++ b/nuxt/pages/admin/feedback.vue
@@ -71,14 +71,14 @@ export default {
   methods: {
     dayjs,
     async loadFeedbacks() {
-      const response = await fetch('/api/admin/feedback', {
-        credentials: 'include',
-      });
-      if (!response.ok) {
-        throw new Error('Failed to load feedbacks');
+      try {
+        const { data: feedbacks } = await this.$http.get('/api/admin/feedback');
+        this.feedbacks = feedbacks;
       }
-      const responseData = await response.json();
-      this.feedbacks = responseData.data;
+      catch (err) {
+        console.error('Failed to load feedbacks:', err);
+        this.feedbacks = [];
+      }
     },
     feedbackKindClass(kind) {
       return {

--- a/nuxt/pages/admin/users/index.vue
+++ b/nuxt/pages/admin/users/index.vue
@@ -234,11 +234,9 @@ export default {
           }
           const responseData = await response.json();
           const {
-            // limit,
-            // offset,
-            results: users,
             size,
-          } = responseData;
+          } = responseData.meta.pagination;
+          const users = responseData.data;
 
           this.users = users;
           this.totalUsers = size;

--- a/nuxt/pages/admin/users/index.vue
+++ b/nuxt/pages/admin/users/index.vue
@@ -221,31 +221,21 @@ export default {
         url.searchParams.set('offset', this.offset);
       }
 
-      return url.toString();
+      return url.pathname + (url.search || '');
     },
-    loadUsers() {
-      const url = this.buildUsersRequestUrl();
-      fetch(url, {
-        credentials: 'include',
-      })
-        .then(async (response) => {
-          if (!response.ok) {
-            throw new Error('Failed to load users');
-          }
-          const responseData = await response.json();
-          const {
-            size,
-          } = responseData.meta.pagination;
-          const users = responseData.data;
-
-          this.users = users;
-          this.totalUsers = size;
-        })
-        .catch((error) => {
-          console.error('Error loading users:', error);
-          this.users = [];
-          this.loadError = true;
-        });
+    async loadUsers() {
+      const path = this.buildUsersRequestUrl();
+      try {
+        const { data: users, meta } = await this.$http.get(path);
+        const { size } = meta.pagination;
+        this.users = users;
+        this.totalUsers = size;
+      }
+      catch (error) {
+        console.error('Error loading users:', error);
+        this.users = [];
+        this.loadError = true;
+      }
     },
     toggleSort(column) {
       if (this.sortOn !== column) {
@@ -278,13 +268,7 @@ export default {
         return;
       }
       try {
-        const response = await fetch(`/api/admin/users/${email}`, {
-          method: 'DELETE',
-          credentials: 'include',
-        });
-        if (!response.ok) {
-          throw new Error('Failed to delete user');
-        }
+        await this.$http.delete(`/api/admin/users/${email}`);
         this.selectedUser = null;
         this.loadUsers();
       }
@@ -313,12 +297,7 @@ export default {
         // Clear any cached data from admin account session
         sessionStorage.clear();
 
-        const response = await fetch(`/api/admin/users/${this.selectedUser.email}/login`, {
-          credentials: 'include',
-        });
-        if (!response.ok) {
-          throw new Error('Unable to sign in as user.');
-        }
+        await this.$http.get(`/api/admin/users/${this.selectedUser.email}/login`);
         // Instead of relying on the store to reload user and data,
         // fully reload the page to ensure the new user is logged in and data is refreshed.
         window.location.href = '/start';

--- a/nuxt/pages/calendar.vue
+++ b/nuxt/pages/calendar.vue
@@ -227,7 +227,7 @@ export default {
   },
   "uk": {
     "page_title": "Календар",
-    "verse": "верс | верси",
+    "verse": "верс | віршів",
     "open_bible": "Читати в Біблії",
     "take_note": "Записати",
     "edit": "Редагувати",

--- a/nuxt/pages/change-email.vue
+++ b/nuxt/pages/change-email.vue
@@ -19,7 +19,7 @@
         <div class="content">
           <p>{{ $t('there_was_an_error_changing_your_email_address') }}</p>
           <p v-if="serverError">
-            {{ serverError }}
+            {{ $terr(serverError) }}
           </p>
           <p>{{ $t('please_go_to_your_settings_and_try_changing_your_email_address_again') }}</p>
         </div>
@@ -29,6 +29,9 @@
 </template>
 
 <script>
+import { ApiError, UnknownApiError } from '~/helpers/api-error';
+import mapFormErrors from '~/helpers/map-form-errors';
+
 export default {
   name: 'ChangeEmailPage',
   data() {
@@ -57,14 +60,8 @@ export default {
     // Determine if change email code is valid
     let changeEmailRequest;
     try {
-      const response = await fetch(`/api/auth/change-email/${newEmailVerificationCode}`, {
-        credentials: 'include',
-      });
-      if (!response.ok) {
-        throw new Error('Failed to get change email request');
-      }
-      const responseData = await response.json();
-      changeEmailRequest = responseData.data;
+      const { data } = await this.$http.get(`/api/auth/change-email/${newEmailVerificationCode}`);
+      changeEmailRequest = data;
     }
     catch (err) {
       // If there is no open email change request (404), redirect to the settings page
@@ -83,22 +80,15 @@ export default {
 
     // Submit change email code to finalize the update
     try {
-      const response = await fetch(`/api/auth/change-email/${newEmailVerificationCode}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
-      if (!response.ok) {
-        const responseData = await response.json();
-        this.serverError = responseData.error;
-        this.busy = false;
-        return;
-      }
+      await this.$http.post(`/api/auth/change-email/${newEmailVerificationCode}`);
     }
     catch (err) {
-      this.serverError = this.$t('an_unknown_error_occurred');
+      if (err instanceof ApiError && err.errors?.length) {
+        this.serverError = this.$terr(err.errors[0]);
+      }
+      else {
+        this.serverError = mapFormErrors(new UnknownApiError())._form;
+      }
       this.busy = false;
       return;
     }

--- a/nuxt/pages/change-email.vue
+++ b/nuxt/pages/change-email.vue
@@ -63,7 +63,8 @@ export default {
       if (!response.ok) {
         throw new Error('Failed to get change email request');
       }
-      changeEmailRequest = await response.json();
+      const responseData = await response.json();
+      changeEmailRequest = responseData.data;
     }
     catch (err) {
       // If there is no open email change request (404), redirect to the settings page
@@ -90,8 +91,8 @@ export default {
         credentials: 'include',
       });
       if (!response.ok) {
-        const errorData = await response.json();
-        this.serverError = errorData.error;
+        const responseData = await response.json();
+        this.serverError = responseData.error;
         this.busy = false;
         return;
       }

--- a/nuxt/pages/daily-reminder-unsubscribe.vue
+++ b/nuxt/pages/daily-reminder-unsubscribe.vue
@@ -72,8 +72,8 @@ export default {
       })
         .then(async (response) => {
           if (response.status === 200) {
-            const data = await response.json();
-            if (data.error) {
+            const responseData = await response.json();
+            if (responseData.error) {
               // if the server can't unsubscribe with this code,
               // it will return an error message explaining why
               this.error = [
@@ -85,7 +85,7 @@ export default {
             else {
               // if there was no error returned, the unsubscribe was successful
               this.complete = true;
-              this.email = data.email;
+              this.email = responseData.data.email;
             }
           }
         })

--- a/nuxt/pages/daily-reminder-unsubscribe.vue
+++ b/nuxt/pages/daily-reminder-unsubscribe.vue
@@ -39,6 +39,8 @@
 </template>
 
 <script>
+import { ApiError } from '~/helpers/api-error';
+
 export default {
   name: 'ReminderUnsubscribePage',
   data() {
@@ -64,34 +66,24 @@ export default {
     this.unsubscribe();
   },
   methods: {
-    unsubscribe() {
-      const unsubscribeUrl = `/api/reminders/daily-reminder/unsubscribe/${this.reminderUnsubscribeCode}`;
-      fetch(unsubscribeUrl, {
-        method: 'PUT',
-        credentials: 'include',
-      })
-        .then(async (response) => {
-          if (response.status === 200) {
-            const responseData = await response.json();
-            if (responseData.error) {
-              // if the server can't unsubscribe with this code,
-              // it will return an error message explaining why
-              this.error = [
-                this.$t('server_error.p1'),
-                this.$t('server_error.p2'),
-                this.$t('server_error.p3'),
-              ].join(' ');
-            }
-            else {
-              // if there was no error returned, the unsubscribe was successful
-              this.complete = true;
-              this.email = responseData.data.email;
-            }
-          }
-        })
-        .catch(() => {
+    async unsubscribe() {
+      try {
+        const { data } = await this.$http.put(`/api/reminders/daily-reminder/unsubscribe/${this.reminderUnsubscribeCode}`);
+        this.complete = true;
+        this.email = data.email;
+      }
+      catch (err) {
+        if (err instanceof ApiError) {
+          this.error = [
+            this.$t('server_error.p1'),
+            this.$t('server_error.p2'),
+            this.$t('server_error.p3'),
+          ].join(' ');
+        }
+        else {
           this.error = this.$t('there_was_an_error');
-        });
+        }
+      }
     },
   },
   auth: false,

--- a/nuxt/pages/google-login.vue
+++ b/nuxt/pages/google-login.vue
@@ -39,13 +39,7 @@ export default {
         const loginLocale = localStorage.getItem('login_language');
         const userLocale = loginLocale || defaultLocale;
 
-        const response = await fetch(`/api/auth/oauth2/google/verify?code=${code}&state=${state}&locale=${userLocale}`, {
-          credentials: 'include',
-        });
-
-        if (!response.ok) {
-          throw new Error('Google OAuth verification failed');
-        }
+        await this.$http.get(`/api/auth/oauth2/google/verify?code=${code}&state=${state}&locale=${userLocale}`);
 
         // Reload user now that auth cookie should be set
         await this.$store.dispatch('auth/refreshUser');

--- a/nuxt/pages/reset-password.vue
+++ b/nuxt/pages/reset-password.vue
@@ -49,6 +49,8 @@
 </template>
 
 <script>
+import mapFormErrors from '~/helpers/map-form-errors';
+
 export default {
   name: 'ResetPasswordPage',
   middleware: ['auth'],
@@ -89,8 +91,8 @@ export default {
     if (!response.ok) {
       this.passwordResetCodeValid = false;
     }
-    const data = await response.json();
-    this.passwordResetCodeValid = data.valid;
+    const responseData = await response.json();
+    this.passwordResetCodeValid = responseData.data.valid;
   },
   methods: {
     resetChangePasswordErrors() {
@@ -122,10 +124,10 @@ export default {
       });
 
       if (!response.ok) {
-        const data = await response.json();
-        const errors = data.errors;
-        if (errors) {
-          Object.assign(this.changePasswordErrors, errors);
+        const responseData = await response.json();
+        if (responseData.error) {
+          const errorsObj = mapFormErrors(responseData.error);
+          Object.assign(this.changePasswordErrors, errorsObj);
         }
         else {
           this.changePasswordErrors._form = this.$t('an_unknown_error_occurred');

--- a/nuxt/pages/reset-password.vue
+++ b/nuxt/pages/reset-password.vue
@@ -49,6 +49,7 @@
 </template>
 
 <script>
+import { ApiError, UnknownApiError } from '~/helpers/api-error';
 import mapFormErrors from '~/helpers/map-form-errors';
 
 export default {
@@ -87,12 +88,13 @@ export default {
     this.passwordResetCode = passwordResetCode;
 
     // Determine if password reset code is valid
-    const response = await fetch(`/api/auth/reset-password/${this.passwordResetCode}/valid`);
-    if (!response.ok) {
+    try {
+      const { data } = await this.$http.get(`/api/auth/reset-password/${this.passwordResetCode}/valid`);
+      this.passwordResetCodeValid = data.valid;
+    }
+    catch {
       this.passwordResetCodeValid = false;
     }
-    const responseData = await response.json();
-    this.passwordResetCodeValid = responseData.data.valid;
   },
   methods: {
     resetChangePasswordErrors() {
@@ -112,33 +114,27 @@ export default {
 
       if (confirmNewPassword !== newPassword) {
         this.changePasswordErrors.confirmNewPassword = this.$t('passwords_must_match');
-        return;
-      }
-
-      const response = await fetch(`/api/auth/reset-password/${this.passwordResetCode}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ newPassword }),
-      });
-
-      if (!response.ok) {
-        const responseData = await response.json();
-        if (responseData.error) {
-          const errorsObj = mapFormErrors(responseData.error);
-          Object.assign(this.changePasswordErrors, errorsObj);
-        }
-        else {
-          this.changePasswordErrors._form = this.$t('an_unknown_error_occurred');
-        }
         this.formBusy = false;
         return;
       }
 
-      // If successful, automatically log the user in
-      await this.$store.dispatch('auth/refreshUser');
-      await this.$router.push(this.localePath('/start'));
+      try {
+        await this.$http.post(`/api/auth/reset-password/${this.passwordResetCode}`, { newPassword });
+        // If successful, automatically log the user in
+        await this.$store.dispatch('auth/refreshUser');
+        await this.$router.push(this.localePath('/start'));
+      }
+      catch (err) {
+        if (err instanceof ApiError) {
+          Object.assign(this.changePasswordErrors, mapFormErrors(err));
+        }
+        else {
+          Object.assign(this.changePasswordErrors, mapFormErrors(new UnknownApiError()));
+        }
+      }
+      finally {
+        this.formBusy = false;
+      }
     },
   },
   meta: {

--- a/nuxt/pages/settings/delete-account.vue
+++ b/nuxt/pages/settings/delete-account.vue
@@ -81,18 +81,12 @@ export default {
   },
   methods: {
     async deleteAccount() {
-      const response = await fetch('/api/settings/delete-account', {
-        method: 'PUT',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
-      if (response.ok) {
+      try {
+        await this.$http.put('/api/settings/delete-account');
         await this.$store.dispatch('auth/logout');
         this.$router.push(this.localePath('/login', this.$i18n.locale));
       }
-      else {
+      catch (err) {
         this.$store.dispatch('toast/add', {
           type: 'error',
           text: this.$t('unable_to_delete'),

--- a/nuxt/pages/settings/export.vue
+++ b/nuxt/pages/settings/export.vue
@@ -139,7 +139,8 @@ export default {
       if (!tagsResponse.ok) {
         throw new Error('Failed to load tags');
       }
-      const tags = await tagsResponse.json();
+      const tagsResponseData = await tagsResponse.json();
+      const tags = tagsResponseData.data;
       const notes = await this.loadAllNotes();
 
       const noteTexts = notes.map(note => this.generateNoteText(note, tags));
@@ -171,7 +172,8 @@ export default {
       if (!tagsResponse.ok) {
         throw new Error('Failed to load tags');
       }
-      const tags = await tagsResponse.json();
+      const tagsResponseData = await tagsResponse.json();
+      const tags = tagsResponseData.data;
       const notes = await this.loadAllNotes();
       this.notesExportJsonFileContent = JSON.stringify({ notes, tags });
     },
@@ -192,10 +194,11 @@ export default {
         if (!response.ok) {
           throw new Error('Failed to load notes');
         }
+        const responseData = await response.json();
         const {
-          results,
           size,
-        } = await response.json();
+        } = responseData.meta.pagination;
+        const results = responseData.data;
         if (allNotes.length < size) {
           allNotes.push(...results);
           offset += 10;

--- a/nuxt/pages/settings/export.vue
+++ b/nuxt/pages/settings/export.vue
@@ -48,6 +48,8 @@ import { mapState } from 'vuex';
 import * as csv from 'csv';
 import * as dayjs from 'dayjs';
 import { Bible } from '@mybiblelog/shared';
+import { UnknownApiError } from '~/helpers/api-error';
+import mapFormErrors from '~/helpers/map-form-errors';
 
 const delimiter = ',';
 
@@ -126,21 +128,20 @@ export default {
     },
     async downloadNotesTextFile() {
       if (!this.notesExportTextFileContent.length) {
-        await this.generateTextDownloadFromNotes();
+        try {
+          await this.generateTextDownloadFromNotes();
+        }
+        catch (err) {
+          this.$store.dispatch('toast/add', { type: 'error', text: this.$terr(mapFormErrors(new UnknownApiError())._form) });
+          return;
+        }
       }
       const today = dayjs().format('YYYY-MM-DD');
       const filename = this.$t('notes_download.text_filename', { today });
       this.generateDownload(filename, this.notesExportTextFileContent);
     },
     async generateTextDownloadFromNotes() {
-      const tagsResponse = await fetch('/api/passage-note-tags', {
-        credentials: 'include',
-      });
-      if (!tagsResponse.ok) {
-        throw new Error('Failed to load tags');
-      }
-      const tagsResponseData = await tagsResponse.json();
-      const tags = tagsResponseData.data;
+      const { data: tags } = await this.$http.get('/api/passage-note-tags');
       const notes = await this.loadAllNotes();
 
       const noteTexts = notes.map(note => this.generateNoteText(note, tags));
@@ -159,21 +160,20 @@ export default {
     },
     async downloadNotesJsonFile() {
       if (!this.notesExportJsonFileContent.length) {
-        await this.generateJsonDownloadFromNotes();
+        try {
+          await this.generateJsonDownloadFromNotes();
+        }
+        catch (err) {
+          this.$store.dispatch('toast/add', { type: 'error', text: this.$terr(mapFormErrors(new UnknownApiError())._form) });
+          return;
+        }
       }
       const today = dayjs().format('YYYY-MM-DD');
       const filename = this.$t('notes_download.json_filename', { today });
       this.generateDownload(filename, this.notesExportJsonFileContent);
     },
     async generateJsonDownloadFromNotes() {
-      const tagsResponse = await fetch('/api/passage-note-tags', {
-        credentials: 'include',
-      });
-      if (!tagsResponse.ok) {
-        throw new Error('Failed to load tags');
-      }
-      const tagsResponseData = await tagsResponse.json();
-      const tags = tagsResponseData.data;
+      const { data: tags } = await this.$http.get('/api/passage-note-tags');
       const notes = await this.loadAllNotes();
       this.notesExportJsonFileContent = JSON.stringify({ notes, tags });
     },
@@ -186,19 +186,8 @@ export default {
       let done = false;
       let offset = 0;
       do {
-        const url = new URL('/api/passage-notes', this.$config.siteUrl);
-        url.searchParams.set('offset', offset);
-        const response = await fetch(url, {
-          credentials: 'include',
-        });
-        if (!response.ok) {
-          throw new Error('Failed to load notes');
-        }
-        const responseData = await response.json();
-        const {
-          size,
-        } = responseData.meta.pagination;
-        const results = responseData.data;
+        const { data: results, meta } = await this.$http.get(`/api/passage-notes?offset=${offset}`);
+        const { size } = meta.pagination;
         if (allNotes.length < size) {
           allNotes.push(...results);
           offset += 10;

--- a/nuxt/pages/settings/password.vue
+++ b/nuxt/pages/settings/password.vue
@@ -46,6 +46,8 @@
 </template>
 
 <script>
+import mapFormErrors from '~/helpers/map-form-errors';
+
 export default {
   name: 'PasswordSettingsPage',
   middleware: ['auth'],
@@ -113,7 +115,7 @@ export default {
 
       try {
         const response = await fetch('/api/auth/change-password', {
-          method: 'POST',
+          method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
           },
@@ -133,8 +135,14 @@ export default {
         }
         else {
           // Display form errors from the server
-          const errorData = await response.json();
-          Object.assign(this.changePasswordErrors, errorData.response?.data?.errors || {});
+          const responseData = await response.json();
+          if (responseData.error) {
+            const errorsObj = mapFormErrors(responseData.error);
+            Object.assign(this.changePasswordErrors, errorsObj);
+          }
+          else {
+            this.changePasswordErrors._form = this.$t('an_unknown_error_occurred');
+          }
         }
       }
       catch (err) {

--- a/nuxt/pages/settings/reminder.vue
+++ b/nuxt/pages/settings/reminder.vue
@@ -38,21 +38,14 @@
 </template>
 
 <script>
+import { ApiError, UnknownApiError } from '~/helpers/api-error';
 import mapFormErrors from '~/helpers/map-form-errors';
 
 export default {
   name: 'ReminderSettingsPage',
   middleware: ['auth'],
   async asyncData({ app }) {
-    const url = new URL('/api/reminders/daily-reminder', app.$config.siteUrl).toString();
-    const response = await fetch(url, {
-      credentials: 'include',
-      headers: {
-        Authorization: app.ssrToken ? `Bearer ${app.ssrToken}` : undefined,
-      },
-    });
-    const responseData = await response.json();
-    const reminder = responseData.data;
+    const { data: reminder } = await app.$http.get('/api/reminders/daily-reminder');
     const {
       hour,
       minute,
@@ -90,45 +83,31 @@ export default {
       const hourMinuteRE = /(\d+):(\d+)/;
       if (!hourMinuteRE.test(time)) {
         this.reminderErrors._form = this.$t('messaging.please_choose_a_time');
+        this.formBusy = false;
         return;
       }
       const [, hour, minute] = hourMinuteRE.exec(time);
       const timezoneOffset = new Date().getTimezoneOffset();
 
       try {
-        const response = await fetch('/api/reminders/daily-reminder', {
-          method: 'PUT',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-          body: JSON.stringify({
-            hour,
-            minute,
-            timezoneOffset,
-            active,
-          }),
+        await this.$http.put('/api/reminders/daily-reminder', {
+          hour,
+          minute,
+          timezoneOffset,
+          active,
         });
-
-        if (response.ok) {
-          this.$store.dispatch('toast/add', {
-            type: 'success',
-            text: this.$t('messaging.reminder_settings_updated_successfully'),
-          });
-        }
-        else {
-          const responseData = await response.json();
-          if (responseData.error) {
-            const errorsObj = mapFormErrors(responseData.error);
-            Object.assign(this.reminderErrors, errorsObj);
-          }
-          else {
-            this.reminderErrors._form = this.$t('messaging.an_unknown_error_occurred');
-          }
-        }
+        this.$store.dispatch('toast/add', {
+          type: 'success',
+          text: this.$t('messaging.reminder_settings_updated_successfully'),
+        });
       }
       catch (err) {
-        this.reminderErrors._form = this.$t('messaging.an_unknown_error_occurred');
+        if (err instanceof ApiError) {
+          Object.assign(this.reminderErrors, mapFormErrors(err));
+        }
+        else {
+          Object.assign(this.reminderErrors, mapFormErrors(new UnknownApiError()));
+        }
       }
       finally {
         this.formBusy = false;

--- a/nuxt/pages/settings/reminder.vue
+++ b/nuxt/pages/settings/reminder.vue
@@ -38,6 +38,8 @@
 </template>
 
 <script>
+import mapFormErrors from '~/helpers/map-form-errors';
+
 export default {
   name: 'ReminderSettingsPage',
   middleware: ['auth'],
@@ -49,7 +51,8 @@ export default {
         Authorization: app.ssrToken ? `Bearer ${app.ssrToken}` : undefined,
       },
     });
-    const reminder = await response.json();
+    const responseData = await response.json();
+    const reminder = responseData.data;
     const {
       hour,
       minute,
@@ -114,8 +117,14 @@ export default {
           });
         }
         else {
-          const errorData = await response.json();
-          Object.assign(this.reminderErrors, errorData.response?.data?.errors || {});
+          const responseData = await response.json();
+          if (responseData.error) {
+            const errorsObj = mapFormErrors(responseData.error);
+            Object.assign(this.reminderErrors, errorsObj);
+          }
+          else {
+            this.reminderErrors._form = this.$t('messaging.an_unknown_error_occurred');
+          }
         }
       }
       catch (err) {

--- a/nuxt/pages/start.vue
+++ b/nuxt/pages/start.vue
@@ -75,8 +75,8 @@ export default {
         Authorization: app.ssrToken ? `Bearer ${app.ssrToken}` : undefined,
       },
     });
-    const data = await response.json();
-    const { startPage, locale } = data;
+    const responseData = await response.json();
+    const { startPage, locale } = responseData.data;
 
     if (startPage !== 'start') {
       // Mapping these individually allows URLs to change separately

--- a/nuxt/pages/start.vue
+++ b/nuxt/pages/start.vue
@@ -67,30 +67,27 @@ export default {
   middleware: ['auth'],
   async asyncData({ app, redirect }) {
     // Redirect to the user's preferred start page if they have one
-    const url = new URL(app.$config.siteUrl); // from nuxt.config.js
-    url.pathname = '/api/settings';
-    const response = await fetch(url.toString(), {
-      credentials: 'include',
-      headers: {
-        Authorization: app.ssrToken ? `Bearer ${app.ssrToken}` : undefined,
-      },
-    });
-    const responseData = await response.json();
-    const { startPage, locale } = responseData.data;
+    try {
+      const { data } = await app.$http.get('/api/settings');
+      const { startPage, locale } = data;
 
-    if (startPage !== 'start') {
-      // Mapping these individually allows URLs to change separately
-      // from the start page names in user settings
-      const redirectPath = {
-        today: '/today',
-        books: '/books',
-        checklist: '/checklist',
-        calendar: '/calendar',
-        notes: '/notes',
-      }[startPage];
-      if (redirectPath) {
-        return redirect(app.localePath(redirectPath, locale));
+      if (startPage !== 'start') {
+        // Mapping these individually allows URLs to change separately
+        // from the start page names in user settings
+        const redirectPath = {
+          today: '/today',
+          books: '/books',
+          checklist: '/checklist',
+          calendar: '/calendar',
+          notes: '/notes',
+        }[startPage];
+        if (redirectPath) {
+          return redirect(app.localePath(redirectPath, locale));
+        }
       }
+    }
+    catch {
+      // If settings fail to load, show the start page
     }
 
     return {};

--- a/nuxt/pages/verify-email.vue
+++ b/nuxt/pages/verify-email.vue
@@ -45,13 +45,15 @@ export default {
 
     const response = await fetch(`/api/auth/verify-email/${emailVerificationCode}`);
     if (!response.ok) {
-      const data = await response.json();
-      const errors = data.errors;
-      if (errors) {
-        Object.assign(this.verificationErrors, errors);
+      const responseData = await response.json();
+      const errors = responseData.error?.errors;
+      if (errors && errors.length > 0) {
+        // Convert array of errors to a single error message
+        const firstError = errors[0];
+        this.error = this.$terr(firstError);
       }
       else {
-        this.verificationErrors._form = this.$t('an_unknown_error_occurred');
+        this.error = this.$t('an_unknown_error_occurred');
       }
       return;
     }

--- a/nuxt/plugins/http.js
+++ b/nuxt/plugins/http.js
@@ -1,0 +1,65 @@
+import { ApiError } from '@/helpers/api-error';
+
+export default function(context, inject) {
+  class Http {
+    get ssrToken() {
+      return context.app?.ssrToken;
+    }
+
+    get baseUrl() {
+      return context.$config.siteUrl;
+    }
+
+    get defaultOptions() {
+      return {
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: this.ssrToken ?
+            `Bearer ${this.ssrToken}` :
+            undefined,
+        },
+      };
+    }
+
+    async request(method, path, options = {}) {
+      const url = new URL(path, this.baseUrl).toString();
+
+      const response = await fetch(url, {
+        method,
+        ...this.defaultOptions,
+        ...options,
+      });
+
+      const json = await response.json();
+
+      if (json?.error) {
+        throw new ApiError(json.error);
+      }
+
+      return json;
+    }
+
+    get(path, options = {}) {
+      return this.request('GET', path, options);
+    }
+
+    post(path, body = {}) {
+      return this.request('POST', path, {
+        body: JSON.stringify(body),
+      });
+    }
+
+    put(path, body = {}) {
+      return this.request('PUT', path, {
+        body: JSON.stringify(body),
+      });
+    }
+
+    delete(path) {
+      return this.request('DELETE', path);
+    }
+  }
+
+  inject('http', new Http());
+}

--- a/nuxt/plugins/translate-api.js
+++ b/nuxt/plugins/translate-api.js
@@ -7,15 +7,12 @@ export default ({ app }, inject) => {
       return error;
     }
 
-    // FIXME: The "field" is redundant since it is only accessed in the template, where it is already known.
-    //        Removing `field` would simplify things.
-    //        It would need to be removed here and in every `makeI18nError` call.
-    const { field, kind, properties: errorProperties } = error;
+    const { field, code, properties: errorProperties } = error;
 
     // Any component can provide additional context, such as the already-translated field name for a form input.
     // For example: $terr(error, { field: $t('label') })
     // This prevents the English word "label" from being used in other translations.
-    const result = app.i18n.t(kind, { field, ...errorProperties, ...componentProperties });
+    const result = app.i18n.t(`api_error.${code}`, { field, ...errorProperties, ...componentProperties });
     return result;
   };
 

--- a/nuxt/store/auth.js
+++ b/nuxt/store/auth.js
@@ -40,7 +40,7 @@ export const actions = {
     }
   },
   async fetchServerUser({ commit }) {
-    const { data: user } = await this.$http.get('/api/auth/user');
+    const { data: { user } } = await this.$http.get('/api/auth/user');
     delete user?.token;
     commit(SET_USER, user);
   },

--- a/nuxt/store/auth.js
+++ b/nuxt/store/auth.js
@@ -30,60 +30,29 @@ export const mutations = {
 export const actions = {
   async login({ commit }, { email, password }) {
     try {
-      const response = await fetch('/api/auth/login', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, password }),
-      });
-      const data = await response.json();
-      if (response.ok) {
-        const { token, ...user } = data;
-        commit(SET_USER, user);
-        return { success: true, error: null };
-      }
-      else {
-        commit(SET_USER, null);
-        return { success: false, error: data.errors };
-      }
+      const { data: responseData } = await this.$http.post('/api/auth/login', { email, password });
+      const { token, ...user } = responseData;
+      commit(SET_USER, user);
     }
     catch (error) {
-      return { success: false, error: error.message };
+      commit(SET_USER, null);
+      throw error;
     }
   },
   async fetchServerUser({ commit }) {
-    const url = new URL('/api/auth/user', this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      headers: {
-        Authorization: `Bearer ${this.app.ssrToken}`,
-      },
-    });
-    const data = await response.json();
-    const { user } = data;
+    const { data: user } = await this.$http.get('/api/auth/user');
     delete user?.token;
     commit(SET_USER, user);
   },
   async refreshUser({ commit }) {
-    const url = new URL('/api/auth/user', this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      credentials: 'include',
-    });
-    const data = await response.json();
-    const { user } = data;
+    const { data: user } = await this.$http.get('/api/auth/user');
     delete user?.token;
     commit(SET_USER, user);
   },
   async logout({ commit }) {
     try {
       // Send API request to delete token from HttpOnly cookie
-      await fetch('/api/auth/logout', {
-        method: 'POST',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      });
+      await this.$http.post('/api/auth/logout');
     }
     catch (error) {
       // This is expected to fail after account deletion

--- a/nuxt/store/log-entries.js
+++ b/nuxt/store/log-entries.js
@@ -57,14 +57,7 @@ export const mutations = {
 
 export const actions = {
   async loadLogEntries({ commit }) {
-    const url = new URL('/api/log-entries', this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      credentials: 'include',
-      headers: {
-        Authorization: this.app?.ssrToken ? `Bearer ${this.app.ssrToken}` : undefined,
-      },
-    });
-    const data = await response.json();
+    const { data } = await this.$http.get('/api/log-entries');
     commit(SET_LOG_ENTRIES, data);
   },
   async createLogEntry({ commit, dispatch, getters }, { date, startVerseId, endVerseId }) {
@@ -76,16 +69,11 @@ export const actions = {
     const wasBookComplete = isBookComplete(bookIndex, currentLogEntries);
     const wasBibleComplete = isBibleComplete(currentLogEntries);
 
-    const response = await fetch(new URL('/api/log-entries', this.$config.siteUrl), {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ date, startVerseId, endVerseId }),
+    const { data } = await this.$http.post('/api/log-entries', {
+      date,
+      startVerseId,
+      endVerseId,
     });
-    const data = await response.json();
-    if (!data) { return null; }
     commit(ADD_LOG_ENTRY, data);
 
     // Check completion after adding the entry
@@ -119,17 +107,11 @@ export const actions = {
     const wasBookComplete = isBookComplete(bookIndex, currentLogEntries);
     const wasBibleComplete = isBibleComplete(currentLogEntries);
 
-    const url = new URL(`/api/log-entries/${id}`, this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      method: 'PUT',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ id, date, startVerseId, endVerseId }),
+    const { data } = await this.$http.put(`/api/log-entries/${id}`, {
+      date,
+      startVerseId,
+      endVerseId,
     });
-    const data = await response.json();
-    if (!data) { return null; }
     commit(UPDATE_LOG_ENTRY, data);
 
     // Check completion after updating the entry
@@ -155,12 +137,7 @@ export const actions = {
     return data;
   },
   async deleteLogEntry({ commit, dispatch, state }, logEntryId) {
-    const url = new URL(`/api/log-entries/${logEntryId}`, this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      method: 'DELETE',
-      credentials: 'include',
-    });
-    const data = await response.json();
+    const { data } = await this.$http.delete(`/api/log-entries/${logEntryId}`);
     if (data) {
       // find the deleted log entry and get its date for efficient cache updating
       const logEntry = state.logEntries.find(logEntry => logEntry.id === logEntryId);

--- a/nuxt/store/log-entry-editor.js
+++ b/nuxt/store/log-entry-editor.js
@@ -1,5 +1,6 @@
 import * as dayjs from 'dayjs';
 import { Bible } from '@mybiblelog/shared';
+import mapFormErrors from '~/helpers/map-form-errors';
 
 import {
   OPEN_LOG_ENTRY_EDITOR,
@@ -238,8 +239,14 @@ export const actions = {
     }
     catch (err) {
       const unknownError = { _form: 'An unknown error occurred' };
-      const errors = err.response?.data?.errors || unknownError;
-      commit(SET_LOG_ENTRY_EDITOR_ERRORS, errors);
+      const errorData = err.response?.data?.error;
+      if (errorData) {
+        const errors = mapFormErrors(errorData) || unknownError;
+        commit(SET_LOG_ENTRY_EDITOR_ERRORS, errors);
+      }
+      else {
+        commit(SET_LOG_ENTRY_EDITOR_ERRORS, unknownError);
+      }
       throw err;
     }
   },

--- a/nuxt/store/passage-note-editor.js
+++ b/nuxt/store/passage-note-editor.js
@@ -1,3 +1,6 @@
+import { ApiError, UnknownApiError } from '@/helpers/api-error';
+import mapFormErrors from '@/helpers/map-form-errors';
+
 import {
   OPEN_PASSAGE_NOTE_EDITOR,
   CLOSE_PASSAGE_NOTE_EDITOR,
@@ -103,10 +106,14 @@ export const actions = {
       return null;
     }
     catch (err) {
-      const unknownError = { _form: 'An unknown error occurred' };
-      const errors = err.response?.data?.errors || unknownError;
-      commit(SET_PASSAGE_NOTE_EDITOR_ERRORS, errors);
-      throw err;
+      if (err instanceof ApiError) {
+        const formErrors = mapFormErrors(err);
+        commit(SET_PASSAGE_NOTE_EDITOR_ERRORS, formErrors);
+      }
+      else {
+        const formErrors = mapFormErrors(new UnknownApiError());
+        commit(SET_PASSAGE_NOTE_EDITOR_ERRORS, formErrors);
+      }
     }
   },
 };

--- a/nuxt/store/passage-note-tag-editor.js
+++ b/nuxt/store/passage-note-tag-editor.js
@@ -1,3 +1,6 @@
+import { ApiError, UnknownApiError } from '@/helpers/api-error';
+import mapFormErrors from '@/helpers/map-form-errors';
+
 import {
   OPEN_PASSAGE_NOTE_TAG_EDITOR,
   CLOSE_PASSAGE_NOTE_TAG_EDITOR,
@@ -89,7 +92,8 @@ export const actions = {
         savedPassageNoteTag = await dispatch('passage-note-tags/updatePassageNoteTag', state.passageNoteTag, { root: true });
       }
       else {
-        savedPassageNoteTag = await dispatch('passage-note-tags/createPassageNoteTag', state.passageNoteTag, { root: true });
+        const data = await dispatch('passage-note-tags/createPassageNoteTag', state.passageNoteTag, { root: true });
+        savedPassageNoteTag = data;
       }
 
       if (savedPassageNoteTag) {
@@ -103,10 +107,14 @@ export const actions = {
       return null;
     }
     catch (err) {
-      const unknownError = { _form: 'An unknown error occurred' };
-      const errors = err.response?.data?.errors || unknownError;
-      commit(SET_PASSAGE_NOTE_TAG_EDITOR_ERRORS, errors);
-      throw err;
+      if (err instanceof ApiError) {
+        const formErrors = mapFormErrors(err);
+        commit(SET_PASSAGE_NOTE_TAG_EDITOR_ERRORS, formErrors);
+      }
+      else {
+        const formErrors = mapFormErrors(new UnknownApiError());
+        commit(SET_PASSAGE_NOTE_TAG_EDITOR_ERRORS, formErrors);
+      }
     }
   },
 };

--- a/nuxt/store/passage-note-tags.js
+++ b/nuxt/store/passage-note-tags.js
@@ -30,59 +30,29 @@ export const mutations = {
 };
 
 export const actions = {
-  async loadPassageNoteTags({ commit, rootState }) {
+  async loadPassageNoteTags({ commit }) {
     // Check for cached data to give an immediate visual response
     let passageNoteTags = BrowserCache.get(PASSAGE_NOTE_TAGS_CACHE_KEY);
     if (passageNoteTags) {
       BrowserCache.set(PASSAGE_NOTE_TAGS_CACHE_KEY, passageNoteTags, PASSAGE_NOTE_TAGS_CACHE_MINUTES);
     }
-    const url = new URL('/api/passage-note-tags', this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      credentials: 'include',
-      headers: {
-        Authorization: this.app?.ssrToken ? `Bearer ${this.app.ssrToken}` : undefined,
-      },
-    });
-    passageNoteTags = await response.json();
+    const { data: passageNoteTagsData } = await this.$http.get('/api/passage-note-tags');
+    passageNoteTags = passageNoteTagsData;
     commit(SET_PASSAGE_NOTE_TAGS, passageNoteTags);
   },
-  async createPassageNoteTag({ commit, dispatch, rootState }, { label, color, description }) {
-    const url = new URL('/api/passage-note-tags', this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ label, color, description }),
-    });
-    const data = await response.json();
-    if (!data) { return null; }
-    commit(ADD_PASSAGE_NOTE_TAG, data);
-    return data;
+  async createPassageNoteTag({ commit }, { label, color, description }) {
+    const { data: result } = await this.$http.post('/api/passage-note-tags', { label, color, description });
+    commit(ADD_PASSAGE_NOTE_TAG, result);
+    return result;
   },
-  async updatePassageNoteTag({ commit, dispatch, rootState }, { id, label, color, description }) {
-    const url = new URL(`/api/passage-note-tags/${id}`, this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      method: 'PUT',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ id, label, color, description }),
-    });
-    const data = await response.json();
+  async updatePassageNoteTag({ commit }, { id, label, color, description }) {
+    const { data } = await this.$http.put(`/api/passage-note-tags/${id}`, { id, label, color, description });
     if (!data) { return null; }
     commit(UPDATE_PASSAGE_NOTE_TAG, data);
     return data;
   },
-  async deletePassageNoteTag({ commit, dispatch, rootState }, passageNoteTagId) {
-    const url = new URL(`/api/passage-note-tags/${passageNoteTagId}`, this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      method: 'DELETE',
-      credentials: 'include',
-    });
-    const data = await response.json();
+  async deletePassageNoteTag({ commit }, passageNoteTagId) {
+    const { data } = await this.$http.delete(`/api/passage-note-tags/${passageNoteTagId}`);
     if (data) {
       commit(REMOVE_PASSAGE_NOTE_TAG, passageNoteTagId);
       return true;

--- a/nuxt/store/passage-notes.js
+++ b/nuxt/store/passage-notes.js
@@ -132,14 +132,12 @@ export const actions = {
       url.searchParams.set('offset', state.query.offset);
     }
 
-    const responseData = await this.$http.get('/api/passage-notes' + url.search);
-
+    const { data: results, meta } = await this.$http.get('/api/passage-notes' + url.search);
     const {
       offset,
       limit,
       size,
-    } = responseData.meta.pagination;
-    const results = responseData.data;
+    } = meta.pagination;
     commit(SET_PASSAGE_NOTES, results);
     commit(SET_PASSAGE_NOTE_PAGINATION, {
       limit,

--- a/nuxt/store/passage-notes.js
+++ b/nuxt/store/passage-notes.js
@@ -132,17 +132,14 @@ export const actions = {
       url.searchParams.set('offset', state.query.offset);
     }
 
-    const response = await fetch(url.toString(), {
-      credentials: 'include',
-    });
-    const responseData = await response.json();
+    const responseData = await this.$http.get('/api/passage-notes' + url.search);
 
     const {
       offset,
       limit,
       size,
-      results,
-    } = responseData;
+    } = responseData.meta.pagination;
+    const results = responseData.data;
     commit(SET_PASSAGE_NOTES, results);
     commit(SET_PASSAGE_NOTE_PAGINATION, {
       limit,
@@ -153,41 +150,18 @@ export const actions = {
     commit(SET_PASSAGE_NOTES_LOADING, false);
   },
   async createPassageNote({ commit, dispatch, rootState }, newPassageNote) {
-    const url = new URL('/api/passage-notes', this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      method: 'POST',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(newPassageNote),
-    });
-    const data = await response.json();
+    const { data } = await this.$http.post('/api/passage-notes', newPassageNote);
     if (!data) { return null; }
     return data;
   },
   async updatePassageNote({ commit, dispatch, rootState }, passageNoteUpdate) {
     const { id } = passageNoteUpdate;
-    const url = new URL(`/api/passage-notes/${id}`, this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      method: 'PUT',
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(passageNoteUpdate),
-    });
-    const data = await response.json();
+    const { data } = await this.$http.put(`/api/passage-notes/${id}`, passageNoteUpdate);
     if (!data) { return null; }
     return data;
   },
   async deletePassageNote({ commit, dispatch, rootState }, passageNoteId) {
-    const url = new URL(`/api/passage-notes/${passageNoteId}`, this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      method: 'DELETE',
-      credentials: 'include',
-    });
-    const data = await response.json();
+    const { data } = await this.$http.delete(`/api/passage-notes/${passageNoteId}`);
     if (data) {
       await dispatch('loadPassageNotesPage');
       return true;

--- a/nuxt/store/user-settings.js
+++ b/nuxt/store/user-settings.js
@@ -78,22 +78,14 @@ export const actions = {
       if (preferredBibleApp) {
         localStorage.setItem(LocalStorageKeys.PREFERRED_BIBLE_APP, preferredBibleApp);
       }
-      const url = new URL('/api/settings', this.$config.siteUrl);
-      await fetch(url.toString(), {
-        method: 'PUT',
-        credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
+      await this.$http.put('/api/settings', {
+        settings: {
+          lookBackDate,
+          dailyVerseCountGoal,
+          preferredBibleVersion,
+          startPage,
+          locale,
         },
-        body: JSON.stringify({
-          settings: {
-            lookBackDate,
-            dailyVerseCountGoal,
-            preferredBibleVersion,
-            startPage,
-            locale,
-          },
-        }),
       });
       commit(SET_USER_SETTINGS, {
         lookBackDate,
@@ -114,14 +106,7 @@ export const actions = {
     await dispatch('loadServerSettings');
   },
   async loadServerSettings({ commit, rootState }) {
-    const url = new URL('/api/settings', this.$config.siteUrl);
-    const response = await fetch(url.toString(), {
-      credentials: 'include',
-      headers: {
-        Authorization: this.app?.ssrToken ? `Bearer ${this.app.ssrToken}` : undefined,
-      },
-    });
-    const data = await response.json();
+    const { data } = await this.$http.get('/api/settings');
     const {
       lookBackDate,
       dailyVerseCountGoal,

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,8 +44,6 @@
         "express": "^5.1.0",
         "form-data": "^4.0.4",
         "helmet": "^8.1.0",
-        "http-errors": "^2.0.0",
-        "http-status": "^2.1.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^9.0.0",
         "mongoose-unique-validator": "^5.0.1",
@@ -18440,15 +18438,6 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
-      }
-    },
-    "node_modules/http-status": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/http-status/-/http-status-2.1.0.tgz",
-      "integrity": "sha512-O5kPr7AW7wYd/BBiOezTwnVAnmSNFY+J7hlZD2X5IOxVBetjcHAiTXhzj0gMrnojQlwy+UT1/Y3H3vJ3UlmvLA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/https-browserify": {


### PR DESCRIPTION
# Description

* Normalizes API response structure across routers: `{ data, meta? } | { error }`
* API errors follow a consistent, client-agnostic structure: `{ code, errors?: [{ field?, code, properties? }] }`
* API errors are now thrown, making router code cleaner and more concise
* Nuxt uses a new client + server $http plugin to make API requests, keeping code concise
* Adds a `mapFormErrors` helper to consistently convert ApiErrors to key-value maps for easy Vue/i18n usage
* Rate limiting is applied to more endpoints
* The Swagger/OpenAPI docs are working again (in dev mode).

