### PR TITLE
Fix passage note content validation

### DIFF
--- a/api/router/routes/passage-notes.ts
+++ b/api/router/routes/passage-notes.ts
@@ -663,7 +663,7 @@ router.put('/passage-notes/:id', async (req, res, next) => {
       throw new NotFoundError();
     }
 
-    if (content) { passageNote.content = content; }
+    if (typeof content === 'string') { passageNote.content = content; }
     if (passages) { passageNote.passages = passages; }
     if (tags) {
       // validate that all tags exist


### PR DESCRIPTION
# Description

Fixes a bug where a passage note's "content" could never be deleted (set to an empty string).

Updates tests to cover this case, along with cleaning up other passage note tests.