### PR TITLE
Add Log page

### DIFF
--- a/nuxt/components/BookReport.vue
+++ b/nuxt/components/BookReport.vue
@@ -1,36 +1,36 @@
 <template>
   <div class="book-report">
     <header class="book-report-header is-hidden-mobile">
-      <div class="book-report-header--title">
-        <button class="button" @click="$emit('exit-book-report')">
-          <caret-left-icon />
-        </button>
-        <h2 class="title mb-0">
-          <span>{{ bookName }}</span>
-        </h2>
-      </div>
-      <div class="buttons">
-        <button class="button" @click="$emit('view-book-notes')">
-          {{ $t('book_notes') }}
-          <caret-right-icon style="margin-left: 0.2rem;" />
-        </button>
-      </div>
+      <button class="button book-report-header__back" @click="$emit('exit-book-report')">
+        <caret-left-icon />
+      </button>
+      <h2 class="title mb-0 book-report-header__title">
+        <span>{{ bookName }}</span>
+      </h2>
+      <button class="button book-report-header__notes" @click="$emit('view-book-notes')">
+        {{ $t('book_notes') }}
+        <caret-right-icon style="margin-left: 0.2rem;" />
+      </button>
+      <button class="button book-report-header__reading" @click="$emit('view-book-log')">
+        {{ $t('book_reading') }}
+        <caret-right-icon style="margin-left: 0.2rem;" />
+      </button>
     </header>
     <header class="book-report-header is-hidden-tablet">
-      <div class="book-report-header--title">
-        <button class="button is-small" @click="$emit('exit-book-report')">
-          <caret-left-icon />
-        </button>
-        <h2 class="title is-5 mb-0">
-          <span>{{ bookName }}</span>
-        </h2>
-      </div>
-      <div class="buttons">
-        <button class="button is-small" @click="$emit('view-book-notes')">
-          {{ $t('book_notes') }}
-          <caret-right-icon style="margin-left: 0.2rem;" />
-        </button>
-      </div>
+      <button class="button is-small book-report-header__back" @click="$emit('exit-book-report')">
+        <caret-left-icon />
+      </button>
+      <h2 class="title is-5 mb-0 book-report-header__title">
+        <span>{{ bookName }}</span>
+      </h2>
+      <button class="button is-small book-report-header__notes" @click="$emit('view-book-notes')">
+        {{ $t('book_notes') }}
+        <caret-right-icon style="margin-left: 0.2rem;" />
+      </button>
+      <button class="button is-small book-report-header__reading" @click="$emit('view-book-log')">
+        {{ $t('book_reading') }}
+        <caret-right-icon style="margin-left: 0.2rem;" />
+      </button>
     </header>
     <div class="plaque">
       <p>
@@ -46,6 +46,7 @@
           @createLogEntry="openAddEntryForm"
           @takeNoteOnChapter="takeNoteOnChapter"
           @viewNotesForChapter="viewNotesForChapter"
+          @viewReadingLogForChapter="viewReadingLogForChapter"
         />
       </template>
     </div>
@@ -56,6 +57,7 @@
 import * as dayjs from 'dayjs';
 import { Bible } from '@mybiblelog/shared';
 import { encodePassageNotesQueryToRoute } from '@/helpers/passage-notes-route-query';
+import { encodeLogEntriesQueryToRoute } from '@/helpers/log-entries-route-query';
 import ChapterReport from '@/components/ChapterReport';
 import SegmentBar from '@/components/SegmentBar';
 import CaretRightIcon from '@/components/svg/CaretRightIcon';
@@ -173,6 +175,18 @@ export default {
       });
       this.$router.push({ path: this.localePath('/notes'), query });
     },
+    viewReadingLogForChapter(bookIndex, chapterIndex) {
+      const chapterVerseCount = Bible.getChapterVerseCount(bookIndex, chapterIndex);
+      const startVerseId = Bible.makeVerseId(bookIndex, chapterIndex, 1);
+      const endVerseId = Bible.makeVerseId(bookIndex, chapterIndex, chapterVerseCount);
+
+      const query = encodeLogEntriesQueryToRoute({
+        filterPassageStartVerseId: startVerseId,
+        filterPassageEndVerseId: endVerseId,
+        offset: 0,
+      });
+      this.$router.push({ path: this.localePath('/log'), query });
+    },
   },
 };
 </script>
@@ -182,16 +196,26 @@ export default {
   user-select: none;
 }
 .book-report-header {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  grid-template-areas: "back title notes reading";
   align-items: center;
+  column-gap: 0.75rem;
+  row-gap: 0.5rem;
   margin-bottom: 1rem;
 }
 
-.book-report-header--title {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
+.book-report-header__back { grid-area: back; }
+.book-report-header__title { grid-area: title; }
+.book-report-header__notes { grid-area: notes; }
+.book-report-header__reading { grid-area: reading; }
+
+@media (max-width: 900px) {
+  .book-report-header {
+    grid-template-areas:
+      "back . notes reading"
+      "title title title title";
+  }
 }
 
 .plaque {
@@ -211,22 +235,28 @@ export default {
 <i18n lang="json">
 {
   "de": {
-    "book_notes": "Buch Notizen"
+    "book_notes": "Buch Notizen",
+    "book_reading": "Buch Lesen"
   },
   "en": {
-    "book_notes": "Book Notes"
+    "book_notes": "Book Notes",
+    "book_reading": "Book Reading"
   },
   "es": {
-    "book_notes": "Notas del libro"
+    "book_notes": "Notas del libro",
+    "book_reading": "Lectura del libro"
   },
   "fr": {
-    "book_notes": "Notes du livre"
+    "book_notes": "Notes du livre",
+    "book_reading": "Lecture du livre"
   },
   "pt": {
-    "book_notes": "Notas do livro"
+    "book_notes": "Notas do livro",
+    "book_reading": "Leitura do livro"
   },
   "uk": {
-    "book_notes": "Нотатки книги"
+    "book_notes": "Нотатки книги",
+    "book_reading": "Читання книги"
   }
 }
 </i18n>

--- a/nuxt/components/ChapterReport.vue
+++ b/nuxt/components/ChapterReport.vue
@@ -50,6 +50,10 @@ export default {
           label: this.$t('view_notes'),
           callback: () => this.viewNotesForChapter(),
         },
+        {
+          label: this.$t('view_reading_log'),
+          callback: () => this.viewReadingLogForChapter(),
+        },
       ];
     },
     sheetTitle() {
@@ -83,6 +87,9 @@ export default {
     },
     viewNotesForChapter() {
       this.$emit('viewNotesForChapter', this.report.bookIndex, this.report.chapterIndex);
+    },
+    viewReadingLogForChapter() {
+      this.$emit('viewReadingLogForChapter', this.report.bookIndex, this.report.chapterIndex);
     },
   },
 };
@@ -156,37 +163,43 @@ export default {
     "open_bible": "Bibel öffnen",
     "log_reading": "Lesen protokollieren",
     "take_note": "Notiz hinzufügen",
-    "view_notes": "Notizen ansehen"
+    "view_notes": "Notizen ansehen",
+    "view_reading_log": "Lesejournal ansehen"
   },
   "en": {
     "open_bible": "Open Bible",
     "log_reading": "Log Reading",
     "take_note": "Take Note",
-    "view_notes": "View Notes"
+    "view_notes": "View Notes",
+    "view_reading_log": "View Reading Log"
   },
   "es": {
     "open_bible": "Abrir en la Biblia",
     "log_reading": "Agregar lectura a registro",
     "take_note": "Tomar nota",
-    "view_notes": "Ver notas"
+    "view_notes": "Ver notas",
+    "view_reading_log": "Ver registro de lectura"
   },
   "fr": {
     "open_bible": "Ouvrir dans la Bible",
     "log_reading": "Ajouter lecture à registre",
     "take_note": "Prendre note",
-    "view_notes": "Voir les notes"
+    "view_notes": "Voir les notes",
+    "view_reading_log": "Voir le journal de lecture"
   },
   "pt": {
     "open_bible": "Ler na Biblia",
     "log_reading": "Adicionar leitura a registro",
     "take_note": "Tomar nota",
-    "view_notes": "Ver notas"
+    "view_notes": "Ver notas",
+    "view_reading_log": "Ver registro de leitura"
   },
   "uk": {
     "open_bible": "Читати в Біблії",
     "log_reading": "Додати читання до журналу",
     "take_note": "Записати",
-    "view_notes": "Переглянути записи"
+    "view_notes": "Переглянути записи",
+    "view_reading_log": "Переглянути журнал читання"
   }
 }
 </i18n>

--- a/nuxt/components/SiteNav.vue
+++ b/nuxt/components/SiteNav.vue
@@ -36,6 +36,9 @@
             <nuxt-link class="navbar-item" :to="localePath('/calendar')">
               {{ $t('calendar') }}
             </nuxt-link>
+            <nuxt-link class="navbar-item" :to="localePath('/log')">
+              {{ $t('log') }}
+            </nuxt-link>
             <nuxt-link class="navbar-item" :to="localePath('/notes')">
               {{ $t('notes') }}
             </nuxt-link>
@@ -140,6 +143,7 @@ export default {
     "bible_books": "Bibelbücher",
     "chapter_checklist": "Kapitel Checkliste",
     "calendar": "Kalender",
+    "log": "Journal",
     "notes": "Notizen",
     "about": "Über",
     "settings": "Einstellungen",
@@ -156,6 +160,7 @@ export default {
     "bible_books": "Bible Books",
     "chapter_checklist": "Chapter Checklist",
     "calendar": "Calendar",
+    "log": "Log",
     "notes": "Notes",
     "about": "About",
     "settings": "Settings",
@@ -172,6 +177,7 @@ export default {
     "bible_books": "Libros Bíblicos",
     "chapter_checklist": "Lista de Capítulos",
     "calendar": "Calendario",
+    "log": "Registro",
     "notes": "Notas",
     "about": "Acerca de",
     "settings": "Configuración",
@@ -188,6 +194,7 @@ export default {
     "bible_books": "Livres de la Bible",
     "chapter_checklist": "Liste de Contrôle",
     "calendar": "Calendrier",
+    "log": "Journal",
     "notes": "Notes",
     "about": "À Propos",
     "settings": "Paramètres",
@@ -204,6 +211,7 @@ export default {
     "bible_books": "Livros da Bíblia",
     "chapter_checklist": "Lista de Capítulos",
     "calendar": "Calendário",
+    "log": "Registro",
     "notes": "Notas",
     "about": "Sobre",
     "settings": "Configurações",
@@ -220,6 +228,7 @@ export default {
     "bible_books": "Книги Біблії",
     "chapter_checklist": "Список розділів",
     "calendar": "Календар",
+    "log": "Журнал",
     "notes": "Нотатки",
     "about": "Про нас",
     "settings": "Налаштування",

--- a/nuxt/components/log/LogEntriesQueryManager.vue
+++ b/nuxt/components/log/LogEntriesQueryManager.vue
@@ -1,0 +1,346 @@
+<template>
+  <div class="log-entries-query-manager">
+    <div>
+      <div class="field">
+        <label class="label">{{ $t('first_date') }}</label>
+        <div class="control">
+          <input
+            v-model.trim="draft.startDate"
+            class="input"
+            type="date"
+            :max="draft.endDate || null"
+          >
+        </div>
+      </div>
+
+      <div class="field">
+        <label class="label">{{ $t('last_date') }}</label>
+        <div class="control">
+          <input
+            v-model.trim="draft.endDate"
+            class="input"
+            type="date"
+            :min="draft.startDate || null"
+          >
+        </div>
+      </div>
+
+      <hr class="log-entries-query-manager__divider">
+
+      <div class="field">
+        <label class="label">{{ $t('passage') }}</label>
+        <div class="log-entries-query-manager__passage-row">
+          <passage-selector
+            :key="passageSelectorKey"
+            :populate-with="passageSelectorPopulateWith"
+            @change="({ startVerseId, endVerseId }) => setDraft({ filterPassageStartVerseId: startVerseId, filterPassageEndVerseId: endVerseId })"
+          />
+          <button
+            v-if="hasSelectedPassage"
+            class="button is-light log-entries-query-manager__clear-button"
+            type="button"
+            @click="clearDraftPassage"
+          >
+            {{ $t('clear') }}
+          </button>
+        </div>
+      </div>
+
+      <hr class="log-entries-query-manager__divider">
+
+      <div class="field">
+        <label class="label">{{ $t('sort') }}</label>
+        <div class="control">
+          <label class="radio">
+            <input v-model="draft.sortDirection" type="radio" value="descending">
+            {{ $t('sort_newest_first') }}
+          </label>
+        </div>
+        <div class="control">
+          <label class="radio">
+            <input v-model="draft.sortDirection" type="radio" value="ascending">
+            {{ $t('sort_oldest_first') }}
+          </label>
+        </div>
+      </div>
+
+      <hr class="log-entries-query-manager__divider">
+
+      <div class="field">
+        <label class="label">{{ $t('page_size') }}</label>
+        <div class="control">
+          <div class="select">
+            <select :value="draft.limit" @change="setDraft({ limit: Number($event.target.value) })">
+              <option :value="10">
+                10
+              </option>
+              <option :value="20">
+                20
+              </option>
+              <option :value="50">
+                50
+              </option>
+            </select>
+          </div>
+        </div>
+      </div>
+
+      <div class="log-entries-query-manager__actions">
+        <button class="button is-primary" type="button" :disabled="!isDirty" @click="applyDraft">
+          {{ $t('apply') }}
+        </button>
+        <button class="button is-light" type="button" :disabled="!isDirty" @click="cancelDraft">
+          {{ $t('cancel') }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { SimpleDate } from '@mybiblelog/shared';
+import PassageSelector from '@/components/forms/PassageSelector';
+
+const DEFAULT_DRAFT = {
+  limit: 10,
+  sortDirection: 'descending',
+  startDate: '',
+  endDate: '',
+  filterPassageStartVerseId: 0,
+  filterPassageEndVerseId: 0,
+};
+
+function normalizeDateString(value) {
+  const v = `${value ?? ''}`.trim();
+  if (!v) { return ''; }
+  return SimpleDate.validateString(v) ? v : '';
+}
+
+function pickManagedQuery(query) {
+  const q = query || {};
+  return {
+    limit: Number(q.limit ?? DEFAULT_DRAFT.limit),
+    sortDirection: q.sortDirection ?? DEFAULT_DRAFT.sortDirection,
+    startDate: normalizeDateString(q.startDate ?? DEFAULT_DRAFT.startDate),
+    endDate: normalizeDateString(q.endDate ?? DEFAULT_DRAFT.endDate),
+    filterPassageStartVerseId: Number(q.filterPassageStartVerseId ?? DEFAULT_DRAFT.filterPassageStartVerseId),
+    filterPassageEndVerseId: Number(q.filterPassageEndVerseId ?? DEFAULT_DRAFT.filterPassageEndVerseId),
+  };
+}
+
+function deepEqualManaged(a, b) {
+  const aa = pickManagedQuery(a);
+  const bb = pickManagedQuery(b);
+  return JSON.stringify(aa) === JSON.stringify(bb);
+}
+
+export default {
+  name: 'LogEntriesQueryManager',
+  components: {
+    PassageSelector,
+  },
+  props: {
+    appliedQuery: {
+      type: Object,
+      default: () => ({}),
+    },
+  },
+  data() {
+    const baseline = pickManagedQuery(this.appliedQuery);
+    return {
+      baseline,
+      draft: pickManagedQuery(this.appliedQuery),
+      passageSelectorKey: 0,
+    };
+  },
+  computed: {
+    isDirty() {
+      return !deepEqualManaged(this.draft, this.baseline);
+    },
+    hasSelectedPassage() {
+      return !!(this.draft.filterPassageStartVerseId && this.draft.filterPassageEndVerseId);
+    },
+    passageSelectorPopulateWith() {
+      if (this.draft.filterPassageStartVerseId && this.draft.filterPassageEndVerseId) {
+        return {
+          empty: false,
+          startVerseId: this.draft.filterPassageStartVerseId,
+          endVerseId: this.draft.filterPassageEndVerseId,
+        };
+      }
+      return { empty: true };
+    },
+  },
+  watch: {
+    appliedQuery: {
+      deep: true,
+      handler(nextAppliedQuery) {
+        if (this.isDirty) { return; }
+        this.baseline = pickManagedQuery(nextAppliedQuery);
+        this.draft = pickManagedQuery(nextAppliedQuery);
+        this.passageSelectorKey += 1;
+      },
+    },
+  },
+  methods: {
+    setDraft(update) {
+      this.draft = { ...this.draft, ...update };
+    },
+    resetDraftToApplied() {
+      this.baseline = pickManagedQuery(this.appliedQuery);
+      this.draft = pickManagedQuery(this.appliedQuery);
+      this.passageSelectorKey += 1;
+    },
+    async confirmAndReset() {
+      const confirmed = await this.$store.dispatch('dialog/confirm', {
+        message: this.$t('reset_confirm'),
+      });
+      if (!confirmed) { return; }
+
+      const update = pickManagedQuery(JSON.parse(JSON.stringify(DEFAULT_DRAFT)));
+      this.baseline = pickManagedQuery(update);
+      this.draft = pickManagedQuery(update);
+      this.passageSelectorKey += 1;
+      this.$emit('apply', update);
+    },
+    clearDraftPassage() {
+      this.setDraft({
+        filterPassageStartVerseId: 0,
+        filterPassageEndVerseId: 0,
+      });
+      this.passageSelectorKey += 1;
+    },
+    applyDraft() {
+      const update = pickManagedQuery(this.draft);
+      this.baseline = pickManagedQuery(update);
+      this.draft = pickManagedQuery(update);
+      this.$emit('apply', update);
+    },
+    cancelDraft() {
+      this.resetDraftToApplied();
+      this.$emit('cancel');
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.log-entries-query-manager__divider {
+  margin: 1rem 0;
+}
+
+.log-entries-query-manager__actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.log-entries-query-manager__passage-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.log-entries-query-manager__clear-button {
+  font-size: 0.85rem;
+  padding: 0.3rem 0.55rem;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+</style>
+
+<i18n lang="json">
+{
+  "de": {
+    "title": "Ansichtsoptionen",
+    "reset": "Zurücksetzen",
+    "reset_confirm": "Möchten Sie die Such-/Filter-/Sortiereinstellungen wirklich zurücksetzen?",
+    "first_date": "Von (Datum)",
+    "last_date": "Bis (Datum)",
+    "passage": "Nach Passage filtern",
+    "clear": "Löschen",
+    "sort": "Sortieren",
+    "sort_newest_first": "Neueste zuerst",
+    "sort_oldest_first": "Älteste zuerst",
+    "page_size": "Seitengröße",
+    "apply": "Anwenden",
+    "cancel": "Abbrechen"
+  },
+  "en": {
+    "title": "View Options",
+    "reset": "Reset",
+    "reset_confirm": "Are you sure you want to reset search/filter/sort settings?",
+    "first_date": "First Date",
+    "last_date": "Last Date",
+    "passage": "Filter by Passage",
+    "clear": "Clear",
+    "sort": "Sort",
+    "sort_newest_first": "Newest First",
+    "sort_oldest_first": "Oldest First",
+    "page_size": "Page Size",
+    "apply": "Apply",
+    "cancel": "Cancel"
+  },
+  "es": {
+    "title": "Opciones de vista",
+    "reset": "Restablecer",
+    "reset_confirm": "¿Está seguro de que desea restablecer la búsqueda / filtros / orden?",
+    "first_date": "Primera fecha",
+    "last_date": "Última fecha",
+    "passage": "Filtrar por pasaje",
+    "clear": "Limpiar",
+    "sort": "Ordenar",
+    "sort_newest_first": "Más reciente primero",
+    "sort_oldest_first": "Más antiguo primero",
+    "page_size": "Tamaño de página",
+    "apply": "Aplicar",
+    "cancel": "Cancelar"
+  },
+  "fr": {
+    "title": "Options d’affichage",
+    "reset": "Réinitialiser",
+    "reset_confirm": "Êtes-vous sûr de vouloir réinitialiser la recherche / les filtres / le tri ?",
+    "first_date": "Première date",
+    "last_date": "Dernière date",
+    "passage": "Filtrer par passage",
+    "clear": "Effacer",
+    "sort": "Trier",
+    "sort_newest_first": "Le plus récent d'abord",
+    "sort_oldest_first": "Plus ancien en premier",
+    "page_size": "Taille de page",
+    "apply": "Appliquer",
+    "cancel": "Annuler"
+  },
+  "pt": {
+    "title": "Opções de visualização",
+    "reset": "Reiniciar",
+    "reset_confirm": "Tem certeza de que deseja reiniciar as configurações de busca / filtro / ordenação?",
+    "first_date": "Primeira data",
+    "last_date": "Última data",
+    "passage": "Filtrar por passagem",
+    "clear": "Limpar",
+    "sort": "Ordenar",
+    "sort_newest_first": "Mais Recentes Primeiro",
+    "sort_oldest_first": "Mais Antigos Primeiro",
+    "page_size": "Tamanho da página",
+    "apply": "Aplicar",
+    "cancel": "Cancelar"
+  },
+  "uk": {
+    "title": "Параметри перегляду",
+    "reset": "Скинути",
+    "reset_confirm": "Ви впевнені, що хочете скинути налаштування пошуку / фільтра / сортування?",
+    "first_date": "Перша дата",
+    "last_date": "Остання дата",
+    "passage": "Фільтрувати за уривком",
+    "clear": "Очистити",
+    "sort": "Сортувати",
+    "sort_newest_first": "Спочатку нові",
+    "sort_oldest_first": "Спочатку старі",
+    "page_size": "Розмір сторінки",
+    "apply": "Застосувати",
+    "cancel": "Скасувати"
+  }
+}
+</i18n>

--- a/nuxt/helpers/log-entries-route-query.js
+++ b/nuxt/helpers/log-entries-route-query.js
@@ -1,0 +1,103 @@
+import { SimpleDate } from '@mybiblelog/shared';
+
+const DEFAULT_LOG_ENTRIES_QUERY = {
+  limit: 10,
+  offset: 0,
+  sortDirection: 'descending', // 'ascending' | 'descending'
+  startDate: '', // inclusive; YYYY-MM-DD
+  endDate: '', // inclusive; YYYY-MM-DD
+  filterPassageStartVerseId: 0,
+  filterPassageEndVerseId: 0,
+};
+
+const MAX_PAGE_SIZE = 50;
+
+function clamp(n, min, max) {
+  return Math.min(Math.max(n, min), max);
+}
+
+function parseIntOr(value, fallback) {
+  const n = typeof value === 'number' ? value : parseInt(`${value}`, 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function pickEnum(value, allowed, fallback) {
+  const v = `${value ?? ''}`;
+  return allowed.includes(v) ? v : fallback;
+}
+
+function normalizeDateString(value) {
+  const v = `${value ?? ''}`.trim();
+  if (!v) { return ''; }
+  return SimpleDate.validateString(v) ? v : '';
+}
+
+/**
+ * Decode a vue-router `$route.query` object into a full log-entries query object.
+ * @param {Record<string, any>} routeQuery
+ * @returns {typeof DEFAULT_LOG_ENTRIES_QUERY}
+ */
+export function decodeLogEntriesRouteQuery(routeQuery = {}) {
+  const filterPassageStartVerseId = parseIntOr(routeQuery.filterPassageStartVerseId, DEFAULT_LOG_ENTRIES_QUERY.filterPassageStartVerseId);
+  const filterPassageEndVerseId = parseIntOr(routeQuery.filterPassageEndVerseId, DEFAULT_LOG_ENTRIES_QUERY.filterPassageEndVerseId);
+
+  return {
+    limit: clamp(parseIntOr(routeQuery.limit, DEFAULT_LOG_ENTRIES_QUERY.limit), 1, MAX_PAGE_SIZE),
+    offset: Math.max(0, parseIntOr(routeQuery.offset, DEFAULT_LOG_ENTRIES_QUERY.offset)),
+    sortDirection: pickEnum(routeQuery.sortDirection, ['ascending', 'descending'], DEFAULT_LOG_ENTRIES_QUERY.sortDirection),
+    startDate: normalizeDateString(routeQuery.startDate),
+    endDate: normalizeDateString(routeQuery.endDate),
+    filterPassageStartVerseId: (filterPassageStartVerseId && filterPassageEndVerseId) ? filterPassageStartVerseId : 0,
+    filterPassageEndVerseId: (filterPassageStartVerseId && filterPassageEndVerseId) ? filterPassageEndVerseId : 0,
+  };
+}
+
+/**
+ * Encode a log-entries query object into a vue-router `query` object.
+ * Intended to be fully reproducible (includes sort + paging).
+ * @param {Partial<typeof DEFAULT_LOG_ENTRIES_QUERY>} query
+ * @returns {Record<string, any>}
+ */
+export function encodeLogEntriesQueryToRoute(query = {}) {
+  const merged = { ...DEFAULT_LOG_ENTRIES_QUERY, ...(query || {}) };
+  const normalized = {
+    limit: clamp(parseIntOr(merged.limit, DEFAULT_LOG_ENTRIES_QUERY.limit), 1, MAX_PAGE_SIZE),
+    offset: Math.max(0, parseIntOr(merged.offset, DEFAULT_LOG_ENTRIES_QUERY.offset)),
+    sortDirection: pickEnum(merged.sortDirection, ['ascending', 'descending'], DEFAULT_LOG_ENTRIES_QUERY.sortDirection),
+    startDate: normalizeDateString(merged.startDate),
+    endDate: normalizeDateString(merged.endDate),
+    filterPassageStartVerseId: parseIntOr(merged.filterPassageStartVerseId, 0),
+    filterPassageEndVerseId: parseIntOr(merged.filterPassageEndVerseId, 0),
+  };
+
+  const out = {};
+
+  if (normalized.limit !== DEFAULT_LOG_ENTRIES_QUERY.limit) {
+    out.limit = `${normalized.limit}`;
+  }
+  if (normalized.offset !== DEFAULT_LOG_ENTRIES_QUERY.offset) {
+    out.offset = `${normalized.offset}`;
+  }
+  if (normalized.sortDirection !== DEFAULT_LOG_ENTRIES_QUERY.sortDirection) {
+    out.sortDirection = normalized.sortDirection;
+  }
+
+  if (normalized.startDate) {
+    out.startDate = normalized.startDate;
+  }
+  if (normalized.endDate) {
+    out.endDate = normalized.endDate;
+  }
+
+  const hasPassageFilter = !!(normalized.filterPassageStartVerseId && normalized.filterPassageEndVerseId);
+  if (hasPassageFilter) {
+    out.filterPassageStartVerseId = `${normalized.filterPassageStartVerseId}`;
+    out.filterPassageEndVerseId = `${normalized.filterPassageEndVerseId}`;
+  }
+
+  return out;
+}
+
+export function defaultLogEntriesQuery() {
+  return JSON.parse(JSON.stringify(DEFAULT_LOG_ENTRIES_QUERY));
+}

--- a/nuxt/pages/books/_book.vue
+++ b/nuxt/pages/books/_book.vue
@@ -1,6 +1,12 @@
 <template>
   <div class="content-column">
-    <book-report :log-entries="logEntries" :book-index="bookIndex" @exit-book-report="viewBibleReport" @view-book-notes="viewBookNotes(bookIndex)" />
+    <book-report
+      :log-entries="logEntries"
+      :book-index="bookIndex"
+      @exit-book-report="viewBibleReport"
+      @view-book-notes="viewBookNotes(bookIndex)"
+      @view-book-log="viewBookLog(bookIndex)"
+    />
   </div>
 </template>
 
@@ -8,6 +14,7 @@
 import { mapGetters } from 'vuex';
 import { Bible } from '@mybiblelog/shared';
 import { encodePassageNotesQueryToRoute } from '@/helpers/passage-notes-route-query';
+import { encodeLogEntriesQueryToRoute } from '@/helpers/log-entries-route-query';
 import BookReport from '@/components/BookReport';
 
 export default {
@@ -51,6 +58,16 @@ export default {
         offset: 0,
       });
       this.$router.push({ path: this.localePath('/notes'), query });
+    },
+    viewBookLog(bookIndex) {
+      const bookStartVerseId = Bible.getFirstBookVerseId(bookIndex);
+      const bookEndVerseId = Bible.getLastBookVerseId(bookIndex);
+      const query = encodeLogEntriesQueryToRoute({
+        filterPassageStartVerseId: bookStartVerseId,
+        filterPassageEndVerseId: bookEndVerseId,
+        offset: 0,
+      });
+      this.$router.push({ path: this.localePath('/log'), query });
     },
   },
 };

--- a/nuxt/pages/log.vue
+++ b/nuxt/pages/log.vue
@@ -1,0 +1,781 @@
+<template>
+  <main>
+    <div class="log-page">
+      <header class="page-header">
+        <h2 class="title">
+          {{ $t('log') }}
+        </h2>
+        <div class="buttons is-align-items-flex-start">
+          <button class="button is-info" type="button" @click="openAddEntryForm">
+            {{ $t('add_entry') }}
+          </button>
+        </div>
+      </header>
+
+      <div class="log-page__mobile-query-button">
+        <button class="button is-light is-small log-page__query-button" type="button" @click="openQueryManagerModal">
+          {{ $t('query_manager.open') }}
+          <span v-if="hasAppliedViewOptions" class="log-page__query-badge" aria-hidden="true" />
+        </button>
+        <button v-if="hasAppliedViewOptions" class="button is-light is-small" type="button" @click="resetViewOptions">
+          {{ $t('query_manager.reset_button') }}
+        </button>
+      </div>
+
+      <div class="columns">
+        <aside class="column is-4 log-page__sidebar">
+          <div class="box log-page__query-manager-box">
+            <div class="log-page__query-manager-actions">
+              <button v-if="hasAppliedViewOptions" class="button is-light is-small" type="button" @click="resetViewOptions">
+                {{ $t('query_manager.reset') }}
+              </button>
+            </div>
+            <log-entries-query-manager
+              ref="sidebarQueryManager"
+              :applied-query="query"
+              @apply="applyQueryManager"
+            />
+          </div>
+        </aside>
+
+        <section class="column log-page__content">
+          <div>
+            <template v-if="loading">
+              <log-entry
+                key="loading"
+                :message="$t('results.loading')"
+                empty
+              />
+            </template>
+            <template v-else-if="!pagedLogEntries.length">
+              <div class="has-background-light p-5">
+                <div class="has-text-centered">
+                  {{ $t('results.no_results') }}
+                </div>
+              </div>
+            </template>
+            <template v-else>
+              <div class="log-page__results-bar">
+                <div class="log-page__results-summary">
+                  {{ querySummary }}
+                </div>
+
+                <div v-if="pagerTotalPages > 1" class="log-page__results-pager">
+                  <div class="field has-addons is-marginless" role="group" :aria-label="$t('pagination.label')">
+                    <p class="control">
+                      <button
+                        class="button is-small is-light"
+                        type="button"
+                        :disabled="pagerPage <= 1"
+                        :aria-label="$t('pagination.prev')"
+                        @click="onPageChanged(pagerPage - 1)"
+                      >
+                        <caret-left-icon width="10px" height="18px" fill="currentColor" />
+                      </button>
+                    </p>
+
+                    <div class="control">
+                      <div class="select is-small">
+                        <select
+                          :value="pagerPage"
+                          :aria-label="$t('pagination.page')"
+                          @change="onPageChanged(Number($event.target.value))"
+                        >
+                          <option v-for="p in pagerTotalPages" :key="p" :value="p">
+                            {{ $t('pagination.page') }} {{ p }}
+                          </option>
+                        </select>
+                      </div>
+                    </div>
+
+                    <p class="control">
+                      <button
+                        class="button is-small is-light"
+                        type="button"
+                        :disabled="pagerPage >= pagerTotalPages"
+                        :aria-label="$t('pagination.next')"
+                        @click="onPageChanged(pagerPage + 1)"
+                      >
+                        <caret-right-icon width="10px" height="18px" fill="currentColor" />
+                      </button>
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div class="log-page__entries" role="list" data-testid="log-entries">
+                <client-only>
+                  <log-entry
+                    v-for="entry of pagedLogEntries"
+                    :key="entry.id"
+                    role="listitem"
+                    :message="displayDate(entry.date)"
+                    :passage="entry"
+                    :actions="actionsForLogEntry(entry)"
+                  />
+                </client-only>
+              </div>
+            </template>
+          </div>
+        </section>
+      </div>
+
+      <transition name="fade" appear>
+        <app-modal v-if="showQueryManagerModal" :title="$t('query_manager.title')" @close="closeQueryManagerModal">
+          <template slot="content">
+            <log-entries-query-manager
+              :applied-query="query"
+              @apply="applyQueryManager"
+              @cancel="closeQueryManagerModal"
+            />
+          </template>
+        </app-modal>
+      </transition>
+    </div>
+  </main>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import { Bible, displayDate } from '@mybiblelog/shared';
+import { decodeLogEntriesRouteQuery, encodeLogEntriesQueryToRoute, defaultLogEntriesQuery } from '@/helpers/log-entries-route-query';
+import { encodePassageNotesQueryToRoute } from '@/helpers/passage-notes-route-query';
+import LogEntry from '@/components/LogEntry';
+import LogEntriesQueryManager from '@/components/log/LogEntriesQueryManager';
+import AppModal from '@/components/popups/AppModal';
+import CaretLeftIcon from '@/components/svg/CaretLeftIcon';
+import CaretRightIcon from '@/components/svg/CaretRightIcon';
+
+function stableCompare(a, b) {
+  if (a === b) { return 0; }
+  return a < b ? -1 : 1;
+}
+
+export default {
+  name: 'LogListPage',
+  components: {
+    LogEntry,
+    LogEntriesQueryManager,
+    AppModal,
+    CaretLeftIcon,
+    CaretRightIcon,
+  },
+  middleware: ['auth'],
+  data() {
+    return {
+      loading: true,
+      showQueryManagerModal: false,
+      lastAppliedLogRouteQueryKey: null,
+      query: defaultLogEntriesQuery(),
+    };
+  },
+  head() {
+    return {
+      title: this.$t('log'),
+    };
+  },
+  computed: {
+    ...mapState({
+      logEntries: state => state['log-entries'].logEntries,
+    }),
+    hasAppliedViewOptions() {
+      const q = this.query || {};
+      const hasDateFilters = !!(q.startDate || q.endDate);
+      const hasPassageFilter = !!(q.filterPassageStartVerseId && q.filterPassageEndVerseId);
+      const hasSortOverride = q.sortDirection && q.sortDirection !== 'descending';
+      const hasPageSizeOverride = Number(q.limit || 10) !== 10;
+      return hasDateFilters || hasPassageFilter || hasSortOverride || hasPageSizeOverride;
+    },
+    hasAppliedFilters() {
+      const q = this.query || {};
+      const hasDateFilters = !!(q.startDate || q.endDate);
+      const hasPassageFilter = !!(q.filterPassageStartVerseId && q.filterPassageEndVerseId);
+      return hasDateFilters || hasPassageFilter;
+    },
+    filteredSortedLogEntries() {
+      const q = this.query || {};
+      const startDate = `${q.startDate || ''}`.trim();
+      const endDate = `${q.endDate || ''}`.trim();
+      const hasPassageFilter = !!(q.filterPassageStartVerseId && q.filterPassageEndVerseId);
+      const filterRange = hasPassageFilter
+        ? { startVerseId: Number(q.filterPassageStartVerseId), endVerseId: Number(q.filterPassageEndVerseId) }
+        : null;
+
+      const filtered = (Array.isArray(this.logEntries) ? this.logEntries : []).filter((entry) => {
+        if (startDate && entry.date < startDate) { return false; }
+        if (endDate && entry.date > endDate) { return false; }
+        if (filterRange) {
+          const entryRange = { startVerseId: entry.startVerseId, endVerseId: entry.endVerseId };
+          if (!Bible.checkRangeOverlap(entryRange, filterRange)) { return false; }
+        }
+        return true;
+      });
+
+      const direction = q.sortDirection === 'ascending' ? 1 : -1;
+      return [...filtered].sort((a, b) => {
+        const cmpDate = stableCompare(a.date, b.date) * direction;
+        if (cmpDate !== 0) { return cmpDate; }
+
+        const cmpStart = stableCompare(Number(a.startVerseId), Number(b.startVerseId));
+        if (cmpStart !== 0) { return cmpStart; }
+
+        const cmpEnd = stableCompare(Number(a.endVerseId), Number(b.endVerseId));
+        if (cmpEnd !== 0) { return cmpEnd; }
+
+        return stableCompare(`${a.id}`, `${b.id}`);
+      });
+    },
+    resultsSize() {
+      return Array.isArray(this.filteredSortedLogEntries) ? this.filteredSortedLogEntries.length : 0;
+    },
+    effectiveLimit() {
+      return Math.max(1, Number((this.query && this.query.limit) || 10));
+    },
+    pagerTotalPages() {
+      return Math.max(1, Math.ceil(this.resultsSize / this.effectiveLimit));
+    },
+    effectiveOffset() {
+      const maxOffset = (this.pagerTotalPages - 1) * this.effectiveLimit;
+      const offset = Math.max(0, Number((this.query && this.query.offset) || 0));
+      return Math.min(offset, maxOffset);
+    },
+    pagerPage() {
+      return Math.floor(this.effectiveOffset / this.effectiveLimit) + 1;
+    },
+    pagedLogEntries() {
+      const offset = this.effectiveOffset;
+      const limit = this.effectiveLimit;
+      return this.filteredSortedLogEntries.slice(offset, offset + limit);
+    },
+    querySummary() {
+      const total = Number(this.resultsSize || 0);
+      const offset = Number(this.effectiveOffset || 0);
+      const limit = Number(this.effectiveLimit || 10);
+      const pageLength = Array.isArray(this.pagedLogEntries) ? this.pagedLogEntries.length : 0;
+
+      const noun = this.hasAppliedFilters ? 'results' : 'entries';
+
+      if (!total) {
+        return this.$t(`query_summary.none.${noun}`);
+      }
+
+      if (total <= limit) {
+        return this.$tc(`query_summary.showing_all.${noun}`, total, {
+          total: this.$n(total, 'grouped'),
+        });
+      }
+
+      const first = offset + 1;
+      const last = offset + pageLength;
+      return this.$tc(`query_summary.showing_range.${noun}`, total, {
+        first: this.$n(first, 'grouped'),
+        last: this.$n(last, 'grouped'),
+        total: this.$n(total, 'grouped'),
+      });
+    },
+  },
+  watch: {
+    '$route.query': {
+      deep: true,
+      immediate: true,
+      async handler() {
+        const decoded = decodeLogEntriesRouteQuery(this.$route.query);
+        const key = JSON.stringify(decoded);
+        if (key === this.lastAppliedLogRouteQueryKey) { return; }
+        this.lastAppliedLogRouteQueryKey = key;
+
+        this.query = decoded;
+
+        if (!this.loading) { return; }
+        await this.loadPageData();
+      },
+    },
+    effectiveOffset(nextOffset) {
+      if (!this.query) { return; }
+      if (Number(this.query.offset || 0) === Number(nextOffset || 0)) { return; }
+      this.pushLogQuery({ ...this.query, offset: nextOffset }, { replace: true });
+    },
+    pagerPage() {
+      if (!process.client) { return; }
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    },
+  },
+  async mounted() {
+    if (this.loading) {
+      await this.loadPageData();
+    }
+  },
+  methods: {
+    displayDate(date) {
+      return displayDate(date, this.$i18n.locale);
+    },
+    async loadPageData() {
+      try {
+        await this.$store.dispatch('loadUserData');
+      }
+      finally {
+        this.loading = false;
+      }
+    },
+    pushLogQuery(nextQuery, { replace = false } = {}) {
+      const path = this.localePath('/log');
+      const query = encodeLogEntriesQueryToRoute(nextQuery);
+      const nav = { path, query };
+      return replace ? this.$router.replace(nav) : this.$router.push(nav);
+    },
+    openQueryManagerModal() {
+      this.showQueryManagerModal = true;
+    },
+    closeQueryManagerModal() {
+      this.showQueryManagerModal = false;
+    },
+    resetViewOptions() {
+      if (!this.hasAppliedViewOptions) { return; }
+      const mgr = this.$refs.sidebarQueryManager;
+      if (!mgr || typeof mgr.confirmAndReset !== 'function') { return; }
+      mgr.confirmAndReset();
+    },
+    async applyQueryManager(update) {
+      await this.pushLogQuery({ ...this.query, ...update, offset: 0 });
+      if (this.showQueryManagerModal) {
+        this.closeQueryManagerModal();
+      }
+    },
+    onPageChanged(newPage) {
+      const clampedPage = Math.min(Math.max(Number(newPage || 1), 1), this.pagerTotalPages);
+      if (clampedPage === this.pagerPage) { return; }
+      const offset = (clampedPage - 1) * this.effectiveLimit;
+      this.pushLogQuery({ ...this.query, offset, limit: this.effectiveLimit });
+    },
+    openAddEntryForm() {
+      this.$store.dispatch('log-entry-editor/openEditor', { empty: true });
+    },
+    actionsForLogEntry(entry) {
+      return [
+        { label: this.$t('open_bible'), callback: () => this.openPassageInBible(entry) },
+        { label: this.$t('take_note'), callback: () => this.takeNoteOnPassage(entry) },
+        { label: this.$t('view_notes'), callback: () => this.viewNotesForPassage(entry) },
+        { label: this.$t('edit'), callback: () => this.openEditEntryForm(entry.id) },
+        { label: this.$t('delete'), callback: () => this.deleteEntry(entry.id) },
+      ];
+    },
+    getReadingUrl(bookIndex, chapterIndex) {
+      return this.$store.getters['user-settings/getReadingUrl'](bookIndex, chapterIndex);
+    },
+    openPassageInBible(passage) {
+      const start = Bible.parseVerseId(passage.startVerseId);
+      const url = this.getReadingUrl(start.book, start.chapter);
+      window.open(url, '_blank');
+    },
+    takeNoteOnPassage(passage) {
+      const { startVerseId, endVerseId } = passage;
+      this.$store.dispatch('passage-note-editor/openEditor', {
+        passages: [{ startVerseId, endVerseId }],
+        content: '',
+      });
+    },
+    viewNotesForPassage(passage) {
+      const { startVerseId, endVerseId } = passage;
+      const query = encodePassageNotesQueryToRoute({
+        filterPassageStartVerseId: startVerseId,
+        filterPassageEndVerseId: endVerseId,
+        offset: 0,
+      });
+      this.$router.push({ path: this.localePath('/notes'), query });
+    },
+    openEditEntryForm(id) {
+      const targetEntry = (this.logEntries || []).find(e => e.id === id);
+      if (!targetEntry) { return; }
+      const { date, startVerseId, endVerseId } = targetEntry;
+      this.$store.dispatch('log-entry-editor/openEditor', {
+        id,
+        date,
+        startVerseId,
+        endVerseId,
+      });
+    },
+    async deleteEntry(id) {
+      const confirmed = await this.$store.dispatch('dialog/confirm', {
+        message: this.$t('messaging.are_you_sure_delete_entry'),
+      });
+      if (!confirmed) { return; }
+      const success = await this.$store.dispatch('log-entries/deleteLogEntry', id);
+      if (!success) {
+        this.$store.dispatch('toast/add', {
+          type: 'error',
+          text: this.$t('messaging.log_entry_could_not_be_deleted'),
+        });
+      }
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.log-page {
+  max-width: 1100px;
+  min-height: 70vh;
+  margin: 0 auto;
+  padding: 3rem 1rem 5rem;
+}
+
+.log-page header.page-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  align-items: flex-start;
+
+  padding: 0; /* match global content-column header behavior */
+}
+
+.log-page__mobile-query-button {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+
+  @media (min-width: $breakpoint) {
+    display: none;
+  }
+}
+
+.log-page__query-button {
+  position: relative;
+  padding-right: 1.25rem; /* room for badge */
+}
+
+.log-page__query-badge {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.35rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: #3273dc; /* Bulma primary */
+  box-shadow: 0 0 0 2px white;
+}
+
+.log-page__sidebar {
+  display: none;
+
+  @media (min-width: $breakpoint) {
+    display: block;
+    position: sticky;
+    top: calc(#{$header-height} + 1rem);
+    align-self: flex-start;
+  }
+}
+
+.log-page__query-manager-box {
+  padding: 0.85rem 1rem 1rem;
+}
+
+.log-page__query-manager-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.75rem;
+}
+
+.log-page__results-bar {
+  position: sticky;
+  top: calc(#{$header-height} + 0.5rem - 1px);
+  z-index: 10;
+
+  background: white;
+  padding: 0.5rem 1rem;
+  margin-left: -0.5rem;
+  margin-right: -0.5rem;
+  border-bottom: 1px solid #eee;
+
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.25rem; /* tighter row gap on small screens */
+
+  @media (min-width: 600px) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+}
+
+.log-page__results-summary {
+  font-size: 0.95rem;
+  color: rgba(54, 54, 54, 0.85);
+  white-space: normal;
+  word-break: break-word;
+}
+
+.log-page__results-pager {
+  display: flex;
+  justify-content: flex-start;
+
+  @media (min-width: 600px) {
+    justify-content: flex-end;
+  }
+}
+</style>
+
+<i18n lang="json">
+{
+  "de": {
+    "log": "Lesejournal",
+    "add_entry": "Hinzufügen",
+    "pagination": {
+      "label": "Seitennavigation",
+      "prev": "Zurück",
+      "next": "Weiter",
+      "page": "Seite"
+    },
+    "query_manager": {
+      "open": "Suchen | Filtern | Sortieren",
+      "title": "Ansichtsoptionen",
+      "reset": "Zurücksetzen",
+      "reset_button": "Ansichtsoptionen zurücksetzen"
+    },
+    "results": {
+      "loading": "Laden...",
+      "no_results": "Keine Ergebnisse"
+    },
+    "open_bible": "Bibel öffnen",
+    "take_note": "Notiz hinzufügen",
+    "view_notes": "Notizen ansehen",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "messaging": {
+      "are_you_sure_delete_entry": "Sind Sie sicher, dass Sie diesen Eintrag löschen möchten?",
+      "log_entry_could_not_be_deleted": "Der Eintrag konnte nicht gelöscht werden."
+    },
+    "query_summary": {
+      "none": {
+        "entries": "Keine Einträge",
+        "results": "Keine Ergebnisse"
+      },
+      "showing_all": {
+        "entries": "Zeige {total} Eintrag | Zeige {total} Einträge",
+        "results": "Zeige {total} Ergebnis | Zeige {total} Ergebnisse"
+      },
+      "showing_range": {
+        "entries": "Zeige {first}–{last} von {total} gesamten Eintrag | Zeige {first}–{last} von {total} gesamten Einträgen",
+        "results": "Zeige {first}–{last} von {total} gesamten Ergebnis | Zeige {first}–{last} von {total} gesamten Ergebnissen"
+      }
+    }
+  },
+  "en": {
+    "log": "Reading Log",
+    "add_entry": "Add",
+    "pagination": {
+      "label": "Pagination",
+      "prev": "Prev",
+      "next": "Next",
+      "page": "Page"
+    },
+    "query_manager": {
+      "open": "Search | Filter | Sort",
+      "title": "View Options",
+      "reset": "Reset",
+      "reset_button": "Reset View Options"
+    },
+    "results": {
+      "loading": "Loading...",
+      "no_results": "No Results"
+    },
+    "open_bible": "Open Bible",
+    "take_note": "Take Note",
+    "view_notes": "View Notes",
+    "edit": "Edit",
+    "delete": "Delete",
+    "messaging": {
+      "are_you_sure_delete_entry": "Are you sure you want to delete this entry?",
+      "log_entry_could_not_be_deleted": "The log entry could not be deleted."
+    },
+    "query_summary": {
+      "none": {
+        "entries": "No log entries",
+        "results": "No results"
+      },
+      "showing_all": {
+        "entries": "Showing {total} entry | Showing {total} entries",
+        "results": "Showing {total} result | Showing {total} results"
+      },
+      "showing_range": {
+        "entries": "Showing {first}–{last} of {total} total entry | Showing {first}–{last} of {total} total entries",
+        "results": "Showing {first}–{last} of {total} total result | Showing {first}–{last} of {total} total results"
+      }
+    }
+  },
+  "es": {
+    "log": "Registro de lectura",
+    "add_entry": "Añadir",
+    "pagination": {
+      "label": "Paginación",
+      "prev": "Anterior",
+      "next": "Siguiente",
+      "page": "Página"
+    },
+    "query_manager": {
+      "open": "Buscar | Filtrar | Ordenar",
+      "title": "Opciones de vista",
+      "reset": "Restablecer",
+      "reset_button": "Restablecer opciones"
+    },
+    "results": {
+      "loading": "Cargando...",
+      "no_results": "Sin resultados"
+    },
+    "open_bible": "Abrir en la Biblia",
+    "take_note": "Tomar nota",
+    "view_notes": "Ver notas",
+    "edit": "Editar",
+    "delete": "Borrar",
+    "messaging": {
+      "are_you_sure_delete_entry": "¿Estás seguro de que quieres borrar esta entrada?",
+      "log_entry_could_not_be_deleted": "No se pudo borrar la entrada."
+    },
+    "query_summary": {
+      "none": {
+        "entries": "Sin registros",
+        "results": "Sin resultados"
+      },
+      "showing_all": {
+        "entries": "Mostrando {total} registro | Mostrando {total} registros",
+        "results": "Mostrando {total} resultado | Mostrando {total} resultados"
+      },
+      "showing_range": {
+        "entries": "Mostrando {first}–{last} de {total} registro total | Mostrando {first}–{last} de {total} registros totales",
+        "results": "Mostrando {first}–{last} de {total} resultado total | Mostrando {first}–{last} de {total} resultados totales"
+      }
+    }
+  },
+  "fr": {
+    "log": "Journal de lecture",
+    "add_entry": "Ajouter",
+    "pagination": {
+      "label": "Pagination",
+      "prev": "Précédent",
+      "next": "Suivant",
+      "page": "Page"
+    },
+    "query_manager": {
+      "open": "Rechercher | Filtrer | Trier",
+      "title": "Options d’affichage",
+      "reset": "Réinitialiser",
+      "reset_button": "Réinitialiser les options"
+    },
+    "results": {
+      "loading": "Chargement...",
+      "no_results": "Aucun résultat"
+    },
+    "open_bible": "Ouvrir dans la Bible",
+    "take_note": "Prendre note",
+    "view_notes": "Voir les notes",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "messaging": {
+      "are_you_sure_delete_entry": "Êtes-vous sûr de vouloir supprimer cette entrée?",
+      "log_entry_could_not_be_deleted": "L’entrée n’a pas pu être supprimée."
+    },
+    "query_summary": {
+      "none": {
+        "entries": "Aucune entrée",
+        "results": "Aucun résultat"
+      },
+      "showing_all": {
+        "entries": "Affichage de {total} entrée | Affichage de {total} entrées",
+        "results": "Affichage de {total} résultat | Affichage de {total} résultats"
+      },
+      "showing_range": {
+        "entries": "Affichage de {first}–{last} sur {total} entrée au total | Affichage de {first}–{last} sur {total} entrées au total",
+        "results": "Affichage de {first}–{last} sur {total} résultat au total | Affichage de {first}–{last} sur {total} résultats au total"
+      }
+    }
+  },
+  "pt": {
+    "log": "Registro de leitura",
+    "add_entry": "Adicionar",
+    "pagination": {
+      "label": "Paginação",
+      "prev": "Anterior",
+      "next": "Próximo",
+      "page": "Página"
+    },
+    "query_manager": {
+      "open": "Buscar | Filtrar | Ordenar",
+      "title": "Opções de visualização",
+      "reset": "Reiniciar",
+      "reset_button": "Reiniciar opções"
+    },
+    "results": {
+      "loading": "Carregando...",
+      "no_results": "Sem resultados"
+    },
+    "open_bible": "Ler na Biblia",
+    "take_note": "Tomar nota",
+    "view_notes": "Ver notas",
+    "edit": "Editar",
+    "delete": "Apagar",
+    "messaging": {
+      "are_you_sure_delete_entry": "Tem certeza de que deseja apagar este registro?",
+      "log_entry_could_not_be_deleted": "Não foi possível apagar este registro."
+    },
+    "query_summary": {
+      "none": {
+        "entries": "Nenhum registro",
+        "results": "Sem resultados"
+      },
+      "showing_all": {
+        "entries": "Mostrando {total} registro | Mostrando {total} registros",
+        "results": "Mostrando {total} resultado | Mostrando {total} resultados"
+      },
+      "showing_range": {
+        "entries": "Mostrando {first}–{last} de {total} registro total | Mostrando {first}–{last} de {total} registros totais",
+        "results": "Mostrando {first}–{last} de {total} resultado total | Mostrando {first}–{last} de {total} resultados totais"
+      }
+    }
+  },
+  "uk": {
+    "log": "Журнал читання",
+    "add_entry": "Додати",
+    "pagination": {
+      "label": "Пагінація",
+      "prev": "Назад",
+      "next": "Далі",
+      "page": "Сторінка"
+    },
+    "query_manager": {
+      "open": "Пошук | Фільтр | Сортування",
+      "title": "Параметри перегляду",
+      "reset": "Скинути",
+      "reset_button": "Скинути параметри"
+    },
+    "results": {
+      "loading": "Завантаження...",
+      "no_results": "Немає результатів"
+    },
+    "open_bible": "Читати в Біблії",
+    "take_note": "Записати",
+    "view_notes": "Переглянути нотатки",
+    "edit": "Редагувати",
+    "delete": "Видалити",
+    "messaging": {
+      "are_you_sure_delete_entry": "Ви впевнені, що хочете видалити цей запис?",
+      "log_entry_could_not_be_deleted": "Не вдалося видалити запис."
+    },
+    "query_summary": {
+      "none": {
+        "entries": "Немає записів",
+        "results": "Немає результатів"
+      },
+      "showing_all": {
+        "entries": "Показано {total} запис | Показано {total} записів",
+        "results": "Показано {total} результат | Показано {total} результатів"
+      },
+      "showing_range": {
+        "entries": "Показано {first}–{last} з {total} запису | Показано {first}–{last} з {total} записів",
+        "results": "Показано {first}–{last} з {total} результату | Показано {first}–{last} з {total} результатів"
+      }
+    }
+  }
+}
+</i18n>

--- a/nuxt/pages/notes.vue
+++ b/nuxt/pages/notes.vue
@@ -17,8 +17,9 @@
         </div>
       </header>
       <div class="notes-page__mobile-query-button">
-        <button class="button is-light is-small" type="button" @click="openQueryManagerModal">
+        <button class="button is-light is-small notes-page__query-button" type="button" @click="openQueryManagerModal">
           {{ $t('query_manager.open') }}
+          <span v-if="hasAppliedViewOptions" class="notes-page__query-badge" aria-hidden="true" />
         </button>
         <button v-if="hasAppliedViewOptions" class="button is-light is-small" type="button" @click="resetViewOptions">
           {{ $t('query_manager.reset_button') }}
@@ -345,6 +346,22 @@ export default {
   @media (min-width: $breakpoint) {
     display: none;
   }
+}
+
+.notes-page__query-button {
+  position: relative;
+  padding-right: 1.25rem; /* room for badge */
+}
+
+.notes-page__query-badge {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.35rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 999px;
+  background: #3273dc; /* Bulma primary */
+  box-shadow: 0 0 0 2px white;
 }
 
 .notes-page__sidebar {


### PR DESCRIPTION
# Description

Adds a `/log` page to display all Log Entries.

Allows users to filter log entries by date or passage.

Other pages link to the `/log` page with filters pre-selected in the URL query, allowing users to quickly see all reading for a book or chapter.
