### PR TITLE
Fix passage filter selector exiting after book selection

### DIFF
--- a/web/app/components/forms/PassageSelector.vue
+++ b/web/app/components/forms/PassageSelector.vue
@@ -162,8 +162,14 @@ type PassageSeed = { empty: true } | { empty?: false; startVerseId: number; endV
 
 const props = withDefaults(defineProps<{
   populateWith?: PassageSeed;
+  // When true the modal chains directly to the next step (book → chapters →
+  // start/end verse) instead of closing after each selection. Used when the
+  // selector is driven purely through its modal (e.g. the hidden picker inside
+  // VerseInput) and its inline "part" chips are not visible to continue the flow.
+  autoAdvance?: boolean;
 }>(), {
   populateWith: () => ({ empty: true }),
+  autoAdvance: false,
 });
 
 const emit = defineEmits<{ change: [value: { startVerseId: number; endVerseId: number }] }>();
@@ -243,34 +249,49 @@ function openSelectStartVerse() { selectionTarget.value = SELECTION.START_VERSE;
 function openSelectEndVerse() { selectionTarget.value = SELECTION.END_VERSE; }
 function endSelection() { selectionTarget.value = null; }
 
+// Determines the next selection step when auto-advancing, following the same
+// book → chapters → verse(s) cascade the inline chips expose. Returns null once
+// the passage is fully resolved so the modal can close.
+function nextAutoStep(state: PassageSelection.PassageSelectionState): SelectionTarget {
+  if (!state.book) { return SELECTION.BOOK; }
+  if (!state.startChapter) { return SELECTION.CHAPTERS; }
+  if (state.startChapter === state.endChapter) {
+    return state.startVerse && state.endVerse ? null : SELECTION.VERSES;
+  }
+  if (!state.startVerse) { return SELECTION.START_VERSE; }
+  if (!state.endVerse) { return SELECTION.END_VERSE; }
+  return null;
+}
+
+// Applies a selection result and either chains to the next step (auto-advance)
+// or closes the modal so the inline chips drive the remaining steps.
+function advanceAfter(result: PassageSelection.PassageSelectionResult) {
+  applyResult(result);
+  selectionTarget.value = props.autoAdvance ? nextAutoStep(result.state) : null;
+}
+
 function selectBook(bookIndex: number) {
-  applyResult(PassageSelection.selectBook(bookIndex));
-  selectionTarget.value = null;
+  advanceAfter(PassageSelection.selectBook(bookIndex));
 }
 
 function selectChapters({ from, to }: { from: number; to: number }) {
-  applyResult(PassageSelection.selectChapters(selected.value, { from, to }));
-  selectionTarget.value = null;
+  advanceAfter(PassageSelection.selectChapters(selected.value, { from, to }));
 }
 
 function selectEndChapter({ from, to }: { from: number; to: number }) {
-  applyResult(PassageSelection.selectEndChapter(selected.value, to || from));
-  selectionTarget.value = null;
+  advanceAfter(PassageSelection.selectEndChapter(selected.value, to || from));
 }
 
 function selectVerses({ from, to }: { from: number; to: number }) {
-  applyResult(PassageSelection.selectVerses(selected.value, { from, to }));
-  selectionTarget.value = null;
+  advanceAfter(PassageSelection.selectVerses(selected.value, { from, to }));
 }
 
 function selectStartVerse({ from, to }: { from: number; to: number }) {
-  applyResult(PassageSelection.selectStartVerse(selected.value, from || to));
-  selectionTarget.value = null;
+  advanceAfter(PassageSelection.selectStartVerse(selected.value, from || to));
 }
 
 function selectEndVerse({ from, to }: { from: number; to: number }) {
-  applyResult(PassageSelection.selectEndVerse(selected.value, to || from));
-  selectionTarget.value = null;
+  advanceAfter(PassageSelection.selectEndVerse(selected.value, to || from));
 }
 
 defineExpose({ openSelectBook });

--- a/web/app/components/forms/VerseInput.vue
+++ b/web/app/components/forms/VerseInput.vue
@@ -106,9 +106,11 @@
     <!-- Multi-verse picker (PassageSelector) -->
     <passage-selector
       v-if="multiVerse"
+      :key="passageSelectorKey"
       ref="passageSelectorRef"
       class="verse-input__hidden-passage-selector"
       :populate-with="passageSelectorPopulateWith"
+      :auto-advance="true"
       @change="onPassageSelectorChange"
     />
   </div>

--- a/web/test/components/PassageSelector.test.ts
+++ b/web/test/components/PassageSelector.test.ts
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { Bible } from '@mybiblelog/shared';
+import PassageSelector from '~/components/forms/PassageSelector.vue';
+import GridSelector from '~/components/forms/GridSelector.vue';
+import TapRangeSelector from '~/components/forms/TapRangeSelector.vue';
+
+const JOHN = 43;
+
+// Drives a step of the modal wizard: emit the selection from whichever picker
+// is currently rendered.
+async function selectBook(wrapper: ReturnType<typeof mount>, book: number) {
+  await wrapper.findComponent(GridSelector).vm.$emit('selection', book);
+  await wrapper.vm.$nextTick();
+}
+
+async function tapRange(wrapper: ReturnType<typeof mount>, from: number, to: number) {
+  await wrapper.findComponent(TapRangeSelector).vm.$emit('selection', { from, to });
+  await wrapper.vm.$nextTick();
+}
+
+describe('PassageSelector auto-advance mode', () => {
+  it('chains book → chapters → verses within the modal instead of exiting after the book', async () => {
+    const wrapper = mount(PassageSelector, { props: { autoAdvance: true } });
+    (wrapper.vm as unknown as { openSelectBook: () => void }).openSelectBook();
+    await wrapper.vm.$nextTick();
+
+    // Book step is showing; picking a multi-chapter book must advance to
+    // chapters rather than close the modal.
+    expect(wrapper.findComponent(GridSelector).exists()).toBe(true);
+    await selectBook(wrapper, JOHN);
+    expect(wrapper.findComponent(GridSelector).exists()).toBe(false);
+    expect(wrapper.findComponent(TapRangeSelector).exists()).toBe(true);
+
+    // Single chapter → advance to the verse-range step.
+    await tapRange(wrapper, 3, 3);
+    expect(wrapper.findComponent(TapRangeSelector).exists()).toBe(true);
+
+    // Pick the verse range; the wizard resolves and emits the final range.
+    await tapRange(wrapper, 16, 18);
+    const emitted = wrapper.emitted('change');
+    expect(emitted).toBeTruthy();
+    expect(emitted!.at(-1)![0]).toEqual({
+      startVerseId: Bible.makeVerseId(JOHN, 3, 16),
+      endVerseId: Bible.makeVerseId(JOHN, 3, 18),
+    });
+  });
+
+  it('walks a multi-chapter range through start and end verse steps', async () => {
+    const wrapper = mount(PassageSelector, { props: { autoAdvance: true } });
+    (wrapper.vm as unknown as { openSelectBook: () => void }).openSelectBook();
+    await wrapper.vm.$nextTick();
+
+    await selectBook(wrapper, JOHN);
+    await tapRange(wrapper, 3, 4); // chapters 3 → 4
+    await tapRange(wrapper, 16, 16); // start verse (John 3:16)
+    await tapRange(wrapper, 2, 2); // end verse (John 4:2)
+
+    const emitted = wrapper.emitted('change');
+    expect(emitted!.at(-1)![0]).toEqual({
+      startVerseId: Bible.makeVerseId(JOHN, 3, 16),
+      endVerseId: Bible.makeVerseId(JOHN, 4, 2),
+    });
+  });
+
+  it('without auto-advance, closes the modal after each selection (chip-driven flow)', async () => {
+    const wrapper = mount(PassageSelector);
+    (wrapper.vm as unknown as { openSelectBook: () => void }).openSelectBook();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent(GridSelector).exists()).toBe(true);
+    await selectBook(wrapper, JOHN);
+    // Modal closes; no picker is shown until the user clicks the next chip.
+    expect(wrapper.findComponent(GridSelector).exists()).toBe(false);
+    expect(wrapper.findComponent(TapRangeSelector).exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
The passage filter on the notes and log pages drives a hidden PassageSelector purely through its modal (via openSelectBook). Because each selection step closed the modal so the inline "part" chips could drive the next step — and those chips are hidden in the filter — the flow exited after the book was chosen, before a chapter or verse could be selected.

Add an opt-in auto-advance mode to PassageSelector that chains directly to the next step (book → chapters → start/end verse) within the modal, mirroring the single-verse picker already in VerseInput. The note editor keeps its existing chip-driven behavior. Also bind the intended remount key so re-opening the filter picker re-seeds from the current value.
